### PR TITLE
Support for multiple BDM devices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ EE_LDFLAGS := -L$(PS2DEV)/gsKit/lib -L$(PS2SDK)/ports/lib -s
 EE_LIBS = -ldebug -lfileXio -lpatches -lelf-loader -lgsKit -ldmaKit -lgskit_toolkit -lpng -lz -ltiff -lpad
 EE_CFLAGS := -mno-gpopt -G0
 
-BIN2C = $(PS2SDK)/bin/BIN2C
+BIN2C = $(PS2SDK)/bin/bin2c
 
 .PHONY: all clean
 

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,6 @@
 
 EE_BIN = nhddl_unc.elf
 EE_BIN_PKD = nhddl.elf
-EE_BIN_M4S = nhddl_m4s_unc.elf
-EE_BIN_PKD_M4S = nhddl_m4s.elf
 
 EE_OBJS = main.o module_init.o common.o iso.o history.o options.o gui.o pad.o launcher.o
 IRX_FILES += sio2man.irx mcman.irx mcserv.irx fileXio.irx iomanX.irx freepad.irx
@@ -23,17 +21,9 @@ EE_LDFLAGS := -L$(PS2DEV)/gsKit/lib -L$(PS2SDK)/ports/lib -s
 EE_LIBS = -ldebug -lfileXio -lpatches -lelf-loader -lgsKit -ldmaKit -lgskit_toolkit -lpng -lz -ltiff -lpad
 EE_CFLAGS := -mno-gpopt -G0
 
-BIN2C = $(PS2SDK)/bin/bin2c
+BIN2C = $(PS2SDK)/bin/BIN2C
 
-ifeq ($(MX4SIO), 1)
- EE_BIN = $(EE_BIN_M4S)
- EE_BIN_PKD = $(EE_BIN_PKD_M4S)
- EE_CFLAGS += -DMX4SIO
-endif
-
-.PHONY: all clean .FORCE
-
-.FORCE:
+.PHONY: all clean
 
 all: $(EE_BIN_PKD)
 
@@ -41,7 +31,7 @@ $(EE_BIN_PKD): $(EE_BIN)
 	ps2-packer $< $@
 
 clean:
-	rm -rf $(EE_BIN) $(EE_BIN_PKD) $(EE_BIN_M4S) $(EE_BIN_PKD_M4S) $(EE_ASM_DIR) $(EE_OBJS_DIR)
+	rm -rf $(EE_BIN) $(EE_BIN_PKD) $(EE_ASM_DIR) $(EE_OBJS_DIR)
 
 # IRX files
 %_irx.c:
@@ -56,7 +46,7 @@ $(EE_ASM_DIR):
 $(EE_OBJS_DIR):
 	@mkdir -p $@
 
-$(EE_OBJS_DIR)%.o: $(EE_SRC_DIR)%.c .FORCE | $(EE_OBJS_DIR)
+$(EE_OBJS_DIR)%.o: $(EE_SRC_DIR)%.c | $(EE_OBJS_DIR)
 	$(EE_CC) $(EE_CFLAGS) $(EE_INCS) -c $< -o $@
 
 $(EE_OBJS_DIR)%.o: $(EE_ASM_DIR)%.c | $(EE_OBJS_DIR)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-# NHDDL — a PS2 exFAT HDD launcher for Neutrino
+# NHDDL — a PS2 exFAT BDM launcher for Neutrino
 
-NHDDL is a memory card-based launcher that scans internal exFAT-formatted HDD for ISO files,
+NHDDL is a memory card-based launcher that scans FAT-formatted BDM devices for ISO files,
 lists them and boots selected ISO via Neutrino.  
-It also supports MX4SIO via a separate executable.
 
 It displays visual Game ID to trigger per-game settings on the Pixel FX line of products and writes to memory card history file before launching the title, triggering per-title memory cards on SD2PSX and MemCard PRO 2.
 
@@ -13,11 +12,19 @@ I have a SCPH-70000 PS2 with internal IDE—microSD mod and RetroGEM installed a
 ## What this is not
 
 This not an attempt at making a Neutrino-based Open PS2 Loader replacement.  
-It __will not__ boot ISOs from anything other than exFAT-formatted internal HDDs.
+It __will not__ boot ISOs from anything other than BDM devices.  
+GSM, PADEMU, IGR and other stuff is out-of-scope of this launcher.
 
 ## Usage
 
 Just put the ELF file into Neutrino folder on your memory card and launch it.  
+By default, NHDDL initializes ATA modules and looks for ISOs on internal HDD.  
+
+### Supported BDM devices
+
+NHDDL reuses Neutrino modules for BDM support and requires them to be present in Neutrino `modules` directory.
+
+#### ATA
 Make sure that Neutrino `modules` directory contains the following IRX files:
 - `bdm.irx` 
 - `isofs.irx`
@@ -25,22 +32,42 @@ Make sure that Neutrino `modules` directory contains the following IRX files:
 - `dev9_ns.irx`
 - `ata_bd.irx`
 
-Those are required to find ISO files on exFAT-formatted HDD, retrieve title ID from ISO, read cover art and config files.
-
-MX4SIO variant requires the following IRX files in Neutrino `modules` directory:
+#### MX4SIO
+The following files are required for MX4SIO:
 - `bdm.irx` 
 - `isofs.irx`
 - `bdmfs_fatfs.irx`
 - `mx4sio_bd_mini.irx`
 
+#### USB
+The following files are required for USB:
+- `bdm.irx` 
+- `isofs.irx`
+- `bdmfs_fatfs.irx`
+- `usbd_mini.irx`
+- `usbmass_bd_mini.irx`
+
+#### UDPBD
+The following files are required for UDPBD:
+- `bdm.irx` 
+- `isofs.irx`
+- `bdmfs_fatfs.irx`
+- `dev9_ns.irx`
+- `smap_udpbd.irx`
+
+UDPBD module requires PS2 IP address to work.  
+NHDDL attempts to retrieve PS2 IP address from the following sources:
+- `udpbd_ip` flag in `nhddl.yml`
+- `SYS-CONF/IPCONFIG.DAT` on the memory card (usually created by w/uLaunchELF)
+
+`udpbd_ip` flag takes priority over `IPCONFIG.DAT`.
+
+See [this](#launcher-configuration-file) section for details on `nhddl.yml`.
+
 ### Storing ISO
 
-ISOs can be stored anywhere on internal HDD.   
+ISOs can be stored anywhere on the storage device.   
 OPL-like folder structure is also supported.
-
-### Enabling progressive (480p) output
-
-To enable 480p output mode for the launcher (not the game) either rename the ELF file from `nhddl.elf` to `nhddl_p.elf` or create an empty file named `480p` next to `nhddl.elf`.
 
 ### Displaying cover art
 
@@ -48,32 +75,38 @@ NHDDL uses the same file naming convention and file format used by OPL.
 Just put **140x200 PNG** files named `<title ID>_COV.png` (e.g. `SLUS_200.02_COV.png`) into the `ART` directory on the root of your HDD.  
 If unsure where to get your cover art from, check out the latest version of [OPL Manager](https://oplmanager.com).
 
-### Configuration files
+## Configuration files
 
-NHDDL stores its config files in `config` directory in the root of internal HDD.
+NHDDL uses YAML-like files to load and store its configuration options.
 
-#### Remembering last launched title
+### Launcher configuration file
 
-To automatically point to the last launched title, NHDDL writes the full ISO path to `lastTitle.txt` (created automatically)
-
-#### Global config file
-
-Arguments that need to be applied to every ISO by default are stored in `global.yaml` file
-
-#### Title-specific arguments
-
-Arguments that need to be applied to a specific ISO are loaded from either  
-`<ISO name>.yaml` or `<title ID><anything>.yaml`.  
-
-File that has the same name as ISO has the priority.  
-NHDDL creates this file automatically when title options are modified and saved in UI.
-
-#### Config file structure
-
-NHDDL uses YAML-like files to store and apply title arguments that are passed to Neutrino on title launch.  
-For a list of valid arguments, see Neutrino README.
+Launcher configuration is loaded from `nhddl.yaml` in `nhddl.elf` folder.  
+The file completely optional and must be used only to enable 480p or use any device other than ATA.  
+By default, 480p is disabled and ATA device is used to look for ISO files.
 
 Example of a valid config file:
+```yaml
+480p: # if this flag exists and is not disabled, enables 480 output
+mode: ata # supported modes: ata (default), mx4sio, udpbd, usb
+udpbd_ip: 192.168.1.6 # PS2 IP address for UDPBD mode
+```
+
+### Configuration files on storage device
+
+NHDDL stores its Neutrino-related config files in `config` directory in the root of BDM device.
+
+#### lastTitle.txt
+
+To point to the last launched title, NHDDL writes the full ISO path to `lastTitle.txt`.  
+This file is created automatically.
+
+#### Argument files
+
+These files store arbitrary arguments that are passed to Neutrino on title launch.  
+For a list of valid arguments, see Neutrino README.
+
+Example of a valid file:
 ```yaml
 # All flags are passed to neutrino as-is for future-proofing, comments are ignored
 # Empty values are treated as a simple flag
@@ -87,7 +120,21 @@ logo:
 
 To mark an argument as disabled by default, `$` is used before the argument name.
 
-#### Internal HDD directory structure example
+NHDDL supports two kinds of argument files:
+
+#### global.yaml
+
+Neutrino arguments that need to be applied to every ISO by default are stored in `global.yaml` file
+
+#### Title-specific files
+
+Neutrino arguments that need to be applied to a specific ISO are loaded from either  
+`<ISO name>.yaml` or `<title ID><anything>.yaml`.  
+
+File that has the same name as ISO has the priority.  
+NHDDL creates this file automatically when title options are modified and saved in UI.
+
+#### BDM device file structure example
 
 `#` marks a comment
 

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ See [this](#launcher-configuration-file) section for details on `nhddl.yml`.
 
 ### Storing ISO
 
-ISOs can be stored anywhere on the storage device.   
-OPL-like folder structure is also supported.
+Just like OPL, NHDDL looks for ISOs in directories named `CD` or `DVD`.
+There is no distinction between CD and DVD images, both can be placed in any of those two directories.
 
 ### Displaying cover art
 
@@ -81,9 +81,9 @@ NHDDL uses YAML-like files to load and store its configuration options.
 
 ### Launcher configuration file
 
-Launcher configuration is loaded from `nhddl.yaml` in `nhddl.elf` folder.  
-The file completely optional and must be used only to enable 480p or use any device other than ATA.  
-By default, 480p is disabled and ATA device is used to look for ISO files.
+Launcher configuration is read from the `nhddl.yaml` file, which must be located in the same directory as `nhddl.elf`.  
+This file is completely optional and must be used only to enable 480p or use any device other than ATA.  
+By default, 480p is disabled and the ATA device is used to look for ISO files.
 
 Example of a valid config file:
 ```yaml
@@ -91,6 +91,7 @@ Example of a valid config file:
 mode: ata # supported modes: ata (default), mx4sio, udpbd, usb
 udpbd_ip: 192.168.1.6 # PS2 IP address for UDPBD mode
 ```
+To disable a flag, you can add `$` before the argument name or just comment it out with `#`.
 
 ### Configuration files on storage device
 
@@ -117,8 +118,8 @@ $mc1: mass:/memcard1.bin # disabled argument
 dbc:
 logo:
 ```
+To disable an argument by default, place a `$` before the argument name.
 
-To mark an argument as disabled by default, `$` is used before the argument name.
 
 NHDDL supports two kinds of argument files:
 

--- a/include/common.h
+++ b/include/common.h
@@ -3,10 +3,27 @@
 
 #include <ps2sdkapi.h>
 
+// Enum for supported modes
+typedef enum {
+  MODE_ATA,
+  MODE_MX4SIO,
+  MODE_UDPBD,
+  MODE_USB
+} ModeType;
+
+// Launcher options
+typedef struct {
+  int is480pEnabled;
+  ModeType mode;
+  char udpbdIp[16];
+} LauncherOptions;
+
 // Storage device base path. Initialized in main.c
 extern const char STORAGE_BASE_PATH[];
 // ELF base path. Initialized in main() during init.
 extern char ELF_BASE_PATH[PATH_MAX + 1];
+// Options
+extern LauncherOptions LAUNCHER_OPTIONS;
 
 // Logs to screen and debug console
 void logString(const char *str, ...);

--- a/include/gui.h
+++ b/include/gui.h
@@ -3,7 +3,7 @@
 
 #include "iso.h"
 
-int uiInit(int enable480p);
+int uiInit();
 int uiLoop(struct TargetList *titles);
 void uiCleanup();
 

--- a/include/module_init.h
+++ b/include/module_init.h
@@ -16,7 +16,8 @@
 
 // Initializes Memory Card modules required to load HDD modules and neutrino ELF
 int init();
-// Inititializes HDD modules located at basePath
+
+// Inititializes BDM modules located at basePath
 int initBDM(char *basePath);
 
 #endif

--- a/include/options.h
+++ b/include/options.h
@@ -86,4 +86,7 @@ void insertCompatModeArg(struct ArgumentList *target, uint8_t modes);
 // Loads both global and title launch arguments, returning pointer to a merged list
 struct ArgumentList *loadLaunchArgumentLists(struct Target *target);
 
+// Parses options file into ArgumentList
+int loadArgumentList(struct ArgumentList *options, char *filePath);
+
 #endif

--- a/src/gui.c
+++ b/src/gui.c
@@ -56,13 +56,13 @@ void init480p(GSGLOBAL *gsGlobal) {
   gsGlobal->Height = 448;
 }
 
-int uiInit(int enable480p) {
+int uiInit() {
   gsGlobal = gsKit_init_global();
   gsGlobal->PrimAlphaEnable = GS_SETTING_ON;
   gsGlobal->DoubleBuffering = GS_SETTING_OFF;
   gsGlobal->ZBuffering = GS_SETTING_OFF;
 
-  if (enable480p) {
+  if (LAUNCHER_OPTIONS.is480pEnabled) {
     printf("Starting UI in progressive mode\n");
     init480p(gsGlobal);
   } else if (gsGlobal->Mode == GS_MODE_PAL) {

--- a/src/iso.c
+++ b/src/iso.c
@@ -88,8 +88,7 @@ int _findISO(DIR *directory, struct TargetList *result) {
         struct Target *title = calloc(sizeof(struct Target), 1);
         title->prev = NULL;
         title->next = NULL;
-        title->fullPath = calloc(sizeof(char), strlen(titlePath) + 1);
-        strcpy(title->fullPath, titlePath);
+        title->fullPath = strdup(titlePath);
 
         // Get file name without the extension
         int nameLength = (int)(fileext - entry->d_name);
@@ -139,8 +138,7 @@ void inline insertIntoList(struct TargetList *result, struct Target *title) {
   struct Target *curTitle = result->last;
 
   // Covert title name to uppercase
-  char *curUppercase = calloc(sizeof(char), strlen(title->name) + 1);
-  strcpy(curUppercase, title->name);
+  char *curUppercase = strdup(title->name);
   toUppercase(curUppercase);
 
   // Overall, title name should not exceed PATH_MAX
@@ -271,12 +269,9 @@ struct Target *copyTarget(struct Target *src) {
   struct Target *copy = calloc(sizeof(struct Target), 1);
   copy->idx = src->idx;
 
-  copy->fullPath = malloc(strlen(src->fullPath) + 1);
-  strcpy(copy->fullPath, src->fullPath);
-  copy->name = malloc(strlen(src->name) + 1);
-  strcpy(copy->name, src->name);
-  copy->id = malloc(strlen(src->id) + 1);
-  strcpy(copy->id, src->id);
+  copy->fullPath = strdup(src->fullPath);
+  copy->name = strdup(src->name);
+  copy->id = strdup(src->id);
 
   return copy;
 }

--- a/src/launcher.c
+++ b/src/launcher.c
@@ -11,11 +11,12 @@
 static const char neutrinoELF[] = "neutrino.elf";
 static char isoArgument[] = "dvd";
 static char bsdArgument[] = "bsd";
-#ifndef MX4SIO
-static char bsdValue[] = "ata";
-#else
-static char bsdValue[] = "mx4sio";
-#endif
+
+// Neutrino bsd values
+#define BSD_ATA "ata"
+#define BSD_MX4SIO "mx4sio"
+#define BSD_UDPBD "udpbd"
+#define BSD_USB "usb"
 
 // Assembles argument lists into argv for Neutrino.
 // Expects argv to be initialized with at least (arguments->total) elements.
@@ -56,6 +57,24 @@ int assembleArgv(struct ArgumentList *arguments, char **argv) {
 // Expects arguments to be initialized
 void launchTitle(struct Target *target, struct ArgumentList *arguments) {
   // Append arguments
+  char *bsdValue;
+  switch (LAUNCHER_OPTIONS.mode) {
+  case MODE_ATA:
+    bsdValue = BSD_ATA;
+    break;
+  case MODE_MX4SIO:
+    bsdValue = BSD_MX4SIO;
+    break;
+  case MODE_UDPBD:
+    bsdValue = BSD_UDPBD;
+    break;
+  case MODE_USB:
+    bsdValue = BSD_USB;
+    break;
+  default:
+    printf("ERROR: Unsupported mode\n");
+    return;
+  }
   appendArgument(arguments, newArgument(bsdArgument, bsdValue));
   appendArgument(arguments, newArgument(isoArgument, target->fullPath));
 
@@ -74,6 +93,7 @@ void launchTitle(struct Target *target, struct ArgumentList *arguments) {
   updateHistoryFile(target->id);
 
   char neutrinoPath[PATH_MAX + 1];
+  neutrinoPath[0] = '\0';
   strcpy(neutrinoPath, ELF_BASE_PATH);
   strcat(neutrinoPath, neutrinoELF);
   printf("ERROR: failed to load %s: %d\n", neutrinoELF, LoadELFFromFile(neutrinoPath, argCount, argv));

--- a/src/main.c
+++ b/src/main.c
@@ -159,7 +159,7 @@ void initOptions(char *basePath) {
       } else if (strcmp(OPTION_MODE, arg->arg) == 0) {
         LAUNCHER_OPTIONS.mode = parseMode(arg->value);
       } else if (strcmp(OPTION_UDPBD_IP, arg->arg) == 0) {
-        strlcpy(LAUNCHER_OPTIONS.udpbdIp, arg->value, sizeof(LAUNCHER_OPTIONS.udpbdIp) - 1);
+        strlcpy(LAUNCHER_OPTIONS.udpbdIp, arg->value, sizeof(LAUNCHER_OPTIONS.udpbdIp));
       }
     }
     arg = arg->next;

--- a/src/main.c
+++ b/src/main.c
@@ -2,6 +2,8 @@
 #include "gui.h"
 #include "iso.h"
 #include "module_init.h"
+#include "options.h"
+#include <ctype.h>
 #include <debug.h>
 #include <fcntl.h>
 #include <stdio.h>
@@ -12,8 +14,19 @@
 const char STORAGE_BASE_PATH[] = "mass:";
 // Path to ELF directory
 char ELF_BASE_PATH[PATH_MAX + 1];
-// Progressive mode file name
-static const char progressiveFile[] = "480p";
+// Launcher options
+LauncherOptions LAUNCHER_OPTIONS;
+// Options file name relative to ELF_BASE_PATH
+static const char optionsFile[] = "nhddl.yaml";
+// The 'X' in "mcX" will be replaced with memory card number in parseIPConfig
+static char ipconfigPath[] = "mcX:/SYS-CONF/IPCONFIG.DAT";
+
+// Supported options
+#define OPTION_480P "480p"
+#define OPTION_MODE "mode"
+#define OPTION_UDPBD_IP "udpbd_ip"
+
+void initOptions(char *basePath);
 
 int main(int argc, char *argv[]) {
   // Initialize the screen
@@ -32,46 +45,31 @@ int main(int argc, char *argv[]) {
   strcat(ELF_BASE_PATH, "/");
   logString("Current working directory is %s\n", ELF_BASE_PATH);
 
-  logString("Loading modules...\n");
-  // Init MC modules
+  logString("Loading basic modules...\n");
+  // Init MC and pad modules
   int res;
   if ((res = init()) != 0) {
-    logString("ERROR: Failed to initialize MC modules: %d\n", res);
+    logString("ERROR: Failed to initialize modules: %d\n", res);
     goto fail;
   }
-  // Init BDM modules
-  if ((res = initBDM(ELF_BASE_PATH)) != 0) {
-    logString("Failed to initialize BDM modules: %d\n", res);
-    goto fail;
-  }
-  logString("Modules loaded\n\n");
 
-  logString("Searching for ISO on %s\n", STORAGE_BASE_PATH);
+  initOptions(ELF_BASE_PATH);
+
+  // Init BDM modules
+  logString("Loading BDM modules...\n");
+  if ((res = initBDM(ELF_BASE_PATH)) != 0) {
+    logString("Failed to initialize modules: %d\n", res);
+    goto fail;
+  }
+
+  logString("\n\nSearching for ISO on %s\n", STORAGE_BASE_PATH);
   struct TargetList *titles = findISO();
   if (titles == NULL) {
     logString("No targets found\n");
     goto fail;
   }
 
-  // If ELF file name ends with _p.elf or
-  // progressiveFile exists in current working directory, enable 480p mode
-  int enable480p = 0;
-  
-  char *suffix = strrchr(argv[0], '_');
-  char progFile[PATH_MAX + 1];
-  snprintf(progFile, PATH_MAX, "%s/%s", ELF_BASE_PATH, progressiveFile);
-
-  if (suffix && strcmp(suffix, "_p.elf") == 0) {
-    enable480p = 1;
-  } else {
-    int fd = open(progFile, O_RDONLY);
-    if (fd >= 0) {
-      close(fd);
-      enable480p = 1;
-    }
-  }
-
-  if ((res = uiInit(enable480p))) {
+  if ((res = uiInit())) {
     printf("ERROR: Failed to init UI: %d\n", res);
     goto fail;
   }
@@ -89,4 +87,88 @@ int main(int argc, char *argv[]) {
 fail:
   sleep(3);
   return 1;
+}
+
+// Parses mode string into enum
+ModeType parseMode(const char *modeStr) {
+  if (!strcmp(modeStr, "ata"))
+    return MODE_ATA;
+  if (!strcmp(modeStr, "mx4sio"))
+    return MODE_MX4SIO;
+  if (!strcmp(modeStr, "udpbd"))
+    return MODE_UDPBD;
+  if (!strcmp(modeStr, "usb"))
+    return MODE_USB;
+  return MODE_ATA;
+}
+
+// Tries to read SYS-CONF/IPCONFIG.DAT from basePath
+void parseIPConfig(LauncherOptions *opts) {
+  int ipconfigFd, count;
+  char ipAddr[16]; // IP address will not be longer than 15 characters
+  for (char i = '0'; i < '2'; i++) {
+    ipconfigPath[2] = i;
+    // Attempt to open history file
+    ipconfigFd = open(ipconfigPath, O_RDONLY);
+    if (ipconfigFd >= 0) {
+      count = read(ipconfigFd, ipAddr, sizeof(ipAddr) - 1);
+      close(ipconfigFd);
+      break;
+    }
+  }
+
+  if ((ipconfigFd < 0) || (count < sizeof(ipAddr) - 1)) {
+    logString("Failed to get IP address from IPCONFIG.DAT\n");
+    return;
+  }
+
+  count = 0; // Reuse count as line index
+  // In case IP address is shorter than 15 chars
+  while (!isspace((unsigned char)ipAddr[count])) {
+    // Advance index until we read a whitespace character
+    count++;
+  }
+
+  strlcpy(opts->udpbdIp, ipAddr, count + 1);
+  return;
+}
+
+// Loads NHDDL options from optionsFile on memory card
+void initOptions(char *basePath) {
+  LAUNCHER_OPTIONS.is480pEnabled = 0;
+  LAUNCHER_OPTIONS.mode = MODE_ATA;
+  LAUNCHER_OPTIONS.udpbdIp[0] = '\0';
+
+  char lineBuffer[PATH_MAX + sizeof(optionsFile) + 1];
+  snprintf(lineBuffer, sizeof(lineBuffer), "%s/%s", basePath, optionsFile);
+
+  // Load NHDDL options file into ArgumentList
+  struct ArgumentList *options = calloc(1, sizeof(struct ArgumentList));
+  if (loadArgumentList(options, lineBuffer)) {
+    logString("Can't load options file, will use defaults\n");
+    freeArgumentList(options);
+    return;
+  }
+
+  // Parse the list into Options
+  struct Argument *arg = options->first;
+  while (arg != NULL) {
+    if (!arg->isDisabled) {
+      if (strcmp(OPTION_480P, arg->arg) == 0) {
+        LAUNCHER_OPTIONS.is480pEnabled = 0;
+      } else if (strcmp(OPTION_MODE, arg->arg) == 0) {
+        LAUNCHER_OPTIONS.mode = parseMode(arg->value);
+      } else if (strcmp(OPTION_UDPBD_IP, arg->arg) == 0) {
+        strlcpy(LAUNCHER_OPTIONS.udpbdIp, arg->value, sizeof(LAUNCHER_OPTIONS.udpbdIp) - 1);
+      }
+    }
+    arg = arg->next;
+  }
+  freeArgumentList(options);
+
+  // If mode is set to UDPBD, but udpbd_ip was not set,
+  // try to get IP from IPCONFIG.DAT
+  if ((LAUNCHER_OPTIONS.mode == MODE_UDPBD) && !strlen(LAUNCHER_OPTIONS.udpbdIp)) {
+    parseIPConfig(&LAUNCHER_OPTIONS);
+  }
 }

--- a/src/options.c
+++ b/src/options.c
@@ -377,10 +377,8 @@ struct Argument *copyArgument(struct Argument *src) {
   struct Argument *copy = calloc(sizeof(struct Argument), 1);
   copy->isGlobal = src->isGlobal;
   copy->isDisabled = src->isDisabled;
-  copy->arg = malloc(strlen(src->arg) + 1);
-  strcpy(copy->arg, src->arg);
-  copy->value = malloc(strlen(src->value) + 1);
-  strcpy(copy->value, src->value);
+  copy->arg = strdup(src->arg);
+  copy->value = strdup(src->value);
   return copy;
 }
 
@@ -392,10 +390,8 @@ void replaceArgument(struct Argument *dst, struct Argument *src) {
   free(dst->value);
   dst->isGlobal = src->isGlobal;
   dst->isDisabled = src->isDisabled;
-  dst->arg = malloc(strlen(src->arg) + 1);
-  strcpy(dst->arg, src->arg);
-  dst->value = malloc(strlen(src->value) + 1);
-  strcpy(dst->value, src->value);
+  dst->arg = strdup(src->arg);
+  dst->value = strdup(src->value);
 }
 
 // Creates new Argument with passed argName and value (without copying)
@@ -512,8 +508,7 @@ void storeCompatModes(struct Argument *target, uint8_t modes) {
 // Inserts a new compat mode arg into the argument list
 void insertCompatModeArg(struct ArgumentList *target, uint8_t modes) {
   struct Argument *newArg = calloc(sizeof(struct Argument), 1);
-  newArg->arg = calloc(sizeof(char), strlen(COMPAT_MODES_ARG) + 1);
-  strcpy(newArg->arg, COMPAT_MODES_ARG);
+  newArg->arg = strdup(COMPAT_MODES_ARG);
 
   newArg->value = calloc(sizeof(char), CM_NUM_MODES + 1);
   storeCompatModes(newArg, modes);


### PR DESCRIPTION
This adds the following features:
- Support for loading launcher configuration from YAML file
- Unified support for BDM devices other than ATA HDD.

The following devices are now supported:
- ATA HDD
- MX4SIO
- USB
- UDPBD