### PR TITLE
Improved external module init, fallbacks for neutrino.elf

### DIFF
--- a/include/module_init.h
+++ b/include/module_init.h
@@ -1,10 +1,7 @@
 #ifndef _HDD_H_
 #define _HDD_H_
 
-// Initializes Memory Card modules required to load HDD modules and neutrino ELF
-int init();
-
-// Inititializes BDM modules located at basePath
-int initBDM(char *basePath);
+// Initializes modules required to browse storage device
+int init_modules(char *basePath);
 
 #endif

--- a/src/module_init.c
+++ b/src/module_init.c
@@ -1,14 +1,13 @@
-#include <errno.h>
+#include "module_init.h"
+#include "common.h"
+#include <fcntl.h>
 #include <iopcontrol.h>
 #include <loadfile.h>
-#include <ps2sdkapi.h>
 #include <sbv_patches.h>
 #include <sifrpc.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
-
-#include "common.h"
-#include "module_init.h"
 
 // Macros for loading embedded IOP modules
 #define IRX_DEFINE(mod)                                                                                                                              \
@@ -17,7 +16,7 @@
 
 #define IRX_LOAD(mod)                                                                                                                                \
   logString("\tloading " #mod "\n");                                                                                                                 \
-  if (SifExecModuleBuffer(mod##_irx, size_##mod##_irx, 0, NULL, &iopret) < 0)                                                                        \
+  if ((ret = SifExecModuleBuffer(mod##_irx, size_##mod##_irx, 0, NULL, &iopret)) < 0)                                                                \
     return ret;                                                                                                                                      \
   if (iopret == 1) {                                                                                                                                 \
     return iopret;                                                                                                                                   \
@@ -31,26 +30,91 @@ IRX_DEFINE(mcman);
 IRX_DEFINE(mcserv);
 IRX_DEFINE(freepad);
 
-// Initializes basic modules required for reading from memory card
-int init() {
-  int ret = 0;
+// External module entry
+typedef struct ExternalModule {
+  char *name;         // Module name (without the path and IRX extension)
+  unsigned char *irx; // Pointer to IRX module
+  u32 size;           // IRX size
+  u32 argLength;      // Argument string length
+  char *argStr;       // Argument string
+  int canFail;        // Indicates if module can fail to load
 
-// If DEBUG is defined, skip IOP reinitialization
-#ifndef DEBUG
-  // Reset IOP
-  SifIopReset("", 0);
+  struct ExternalModule *next; // Next module in the list
+} ExternalModule;
+
+// Loads external modules into memory
+ExternalModule *buildExternalModuleList(char *basePath);
+
+// Frees mod and returns pointer to the next module in chain
+ExternalModule *freeExternalModule(ExternalModule *mod);
+
+// Function used to initialize module arguments.
+// Must set argLength and argStr and return 0 if successful.
+// argStr pointer must be unique to ExternalModule
+typedef int (*moduleArgFunc)(ExternalModule *);
+
+typedef struct ExternalModuleEntry {
+  char *name;                     // Module name
+  char *path;                     // Relative path to module
+  moduleArgFunc argumentFunction; // Function used to initialize module arguments
+  int canFail;                    // If not zero, module failing to load will not be considered a critical error
+} ExternalModuleEntry;
+
+// Initializes SMAP arguments
+int initSMAPArguments(ExternalModule *mod);
+
+#define MODULE_COUNT(a) sizeof(a) / sizeof(ExternalModuleEntry)
+const ExternalModuleEntry external_modules[] = {
+    // DEV9
+    {"dev9", "modules/dev9_ns.irx", NULL, 0},
+    // BDM
+    {"bdm", "modules/bdm.irx", NULL, 0},
+    // Required for getting title ID from ISO
+    {"isofs", "modules/isofs.irx", NULL, 0},
+    // FAT/exFAT
+    {"bdmfs_fatfs", "modules/bdmfs_fatfs.irx", NULL, 0},
+    // ATA
+    {"ata_bd", "modules/ata_bd.irx", NULL, 1},
+    // USBD
+    {"usbd_mini", "modules/usbd_mini.irx", NULL, 1},
+    // USB Mass Storage
+    {"usbmass_bd_mini", "modules/usbmass_bd_mini.irx", NULL, 1},
+    // MX4SIO
+    {"mx4sio_bd_mini", "modules/mx4sio_bd_mini.irx", NULL, 1},
+    // SMAP driver. Actually includes small IP stack and UDPTTY
+    {"smap_udpbd", "modules/smap_udpbd.irx", &initSMAPArguments, 1},
+    // iLink
+    // {"iLinkman", "modules/iLinkman.irx", NULL, 1},
+    // iLink Mass Storage
+    // {"IEEE1394_bd_mini", "modules/IEEE1394_bd_mini.irx", NULL, 1},
+};
+
+// Initializes IOP modules
+int init_modules(char *basePath) {
+  // Load optional modules into EE memory before resetting IOP
+  ExternalModule *modules = buildExternalModuleList(basePath);
+  if (modules == NULL) {
+    logString("WARN: No external modules will be loaded\n");
+  }
+
+  // Initialize the RPC manager and reset IOP
+  SifInitRpc(0);
+  while (!SifIopReset("", 0)) {
+  };
+  while (!SifIopSync()) {
+  };
+
   // Initialize the RPC manager
   SifInitRpc(0);
 
-  // Apply patches required to load modules from EE RAM
+  int ret, iopret = 0;
+  // // Apply patches required to load modules from EE RAM
   if ((ret = sbv_patch_enable_lmb()))
     return ret;
   if ((ret = sbv_patch_disable_prefix_check()))
     return ret;
-#endif
 
   // Load modules
-  int iopret = 0;
   IRX_LOAD(iomanX);
   IRX_LOAD(fileXio);
   IRX_LOAD(sio2man);
@@ -58,147 +122,133 @@ int init() {
   IRX_LOAD(mcserv);
   IRX_LOAD(freepad);
 
+  // Load external modules from EE RAM
+  while (modules != NULL) {
+    if (modules->argStr != NULL)
+      logString("\tloading %s with %s\n", modules->name, modules->argStr);
+    else
+      logString("\tloading %s\n", modules->name);
+
+    ret = SifExecModuleBuffer(modules->irx, modules->size, modules->argLength, modules->argStr, &iopret);
+    // Ignore error if module can fail
+    if (!modules->canFail) {
+      if (ret < 0)
+        return ret;
+      if (iopret == 1)
+        return iopret;
+    }
+    modules = freeExternalModule(modules);
+  }
   return 0;
 }
 
-// Loads modules from basePath
-int initExtraModules(char *basePath, int numModules, const char *modules[]) {
+// Frees mod and returns pointer to the next module in chain
+ExternalModule *freeExternalModule(ExternalModule *mod) {
+  ExternalModule *m = mod->next;
+  free(mod->irx);
+  free(mod->argStr);
+  return m;
+}
+
+// Builds IP address argument for SMAP modules
+int initSMAPArguments(ExternalModule *mod) {
+  if (LAUNCHER_OPTIONS.udpbdIp[0] == '\0') {
+    return -ENOENT;
+  }
+
+  char ipArg[19]; // 15 bytes for IP string + 3 bytes for 'ip='
+  mod->argLength = 19;
+  mod->argStr = calloc(sizeof(char), 19);
+  snprintf(mod->argStr, sizeof(ipArg), "ip=%s", LAUNCHER_OPTIONS.udpbdIp);
+  return 0;
+}
+
+// Loads external modules into memory
+ExternalModule *buildExternalModuleList(char *basePath) {
   // Allocate memory for module paths
   int basePathLen = strlen(basePath);
   char pathBuf[PATH_MAX + 1];
   pathBuf[0] = '\0';
   strcpy(pathBuf, basePath);
 
-  // Load modules
-  int ret, iopret;
-  for (int i = 0; i < numModules; i++) {
-    strcat(pathBuf, modules[i]); // Append module path to base path
-    logString("\tloading %s\n", pathBuf);
-    ret = SifLoadStartModule(pathBuf, 0, NULL, &iopret);
-    if (ret < 0) {
-      return ret;
+  ExternalModule *curModule = NULL;
+  ExternalModule *firstModule = NULL;
+  int fd, fsize, res;
+  for (int i = 0; i < MODULE_COUNT(external_modules); i++) {
+    // End bufferred string at basePath for the next strcat in the loop
+    pathBuf[basePathLen] = '\0';
+
+    // Append module path to base path
+    strcat(pathBuf, external_modules[i].path);
+
+    // Open module
+    if ((fd = open(pathBuf, O_RDONLY)) < 0) {
+      logString("%s: Failed to open %s\n", external_modules[i].name, pathBuf);
+      if (!external_modules[i].canFail)
+        goto fail;
+      continue;
     }
-    if (iopret == 1) {
-      return iopret;
+    // Determine file size
+    fsize = lseek(fd, 0, SEEK_END);
+    lseek(fd, 0, SEEK_SET);
+
+    // Allocate memory for the module
+    unsigned char *irxBuf = calloc(sizeof(char), fsize);
+    if (irxBuf == NULL) {
+      logString("\t%s: Failed to allocate memory\n", external_modules[i].name);
+      free(irxBuf);
+      close(fd);
+      goto fail;
     }
-    pathBuf[basePathLen] = '\0'; // End bufferred string at basePath for the next strcat in the loop
+    // Load module into buffer
+    res = read(fd, irxBuf, fsize);
+    if (res != fsize) {
+      logString("\t%s: Failed to read module\n", external_modules[i].name);
+      free(irxBuf);
+      close(fd);
+      goto fail;
+    }
+    close(fd);
+
+    // Initialize ExternalModule
+    ExternalModule *mod = calloc(sizeof(ExternalModule), 1);
+    mod->name = external_modules[i].name;
+    mod->irx = irxBuf;
+    mod->size = fsize;
+    mod->canFail = external_modules[i].canFail;
+
+    // If module has an arugment function, execute it
+    if (external_modules[i].argumentFunction != NULL) {
+      res = external_modules[i].argumentFunction(mod);
+      if (res) {
+        free(irxBuf);
+        free(mod);
+        // Ignore errors if module can fail
+        if (external_modules[i].canFail) {
+          logString("\t%s: Failed to initialize arguments, skipping module\n", external_modules[i].name);
+          continue;
+        } else {
+          logString("\t%s: Failed to initialize arguments\n", external_modules[i].name);
+          goto fail;
+        }
+      }
+    }
+
+    // Add module to chain
+    if (firstModule == NULL)
+      firstModule = mod;
+    else
+      curModule->next = mod;
+
+    curModule = mod;
   }
 
-  return 0;
-}
+  return firstModule;
 
-#define MODULE_COUNT(a) sizeof(a) / sizeof(char *)
-// Base BDM modules
-const char *bdm_base_modules[] = {
-    // BDM
-    "modules/bdm.irx",
-    // Required for getting title ID from ISO
-    "modules/isofs.irx",
-    // FAT/exFAT
-    "modules/bdmfs_fatfs.irx",
-};
-
-// ATA modules
-const char *ata_modules[] = {
-    // DEV9
-    "modules/dev9_ns.irx",
-    // ATA
-    "modules/ata_bd.irx",
-};
-
-// MX4SIO modules
-const char *mx4sio_modules[] = {
-    "modules/mx4sio_bd_mini.irx",
-};
-
-// UDPBD modules
-const char *udpbd_modules[] = {
-    // DEV9
-    "modules/dev9_ns.irx",
-    // SMAP driver.
-    // Treated as a special case because of the IP address argument
-    "modules/smap_udpbd.irx",
-};
-
-// USB modules
-const char *usb_modules[] = {
-    // USBD
-    "modules/usbd_mini.irx",
-    // USB Mass Storage
-    "modules/usbmass_bd_mini.irx",
-};
-
-int initATA(char *basePath) {
-  int res = 0;
-  if ((res = initExtraModules(basePath, MODULE_COUNT(bdm_base_modules), bdm_base_modules))) {
-    return res;
+fail:
+  // Release memory and return NULL
+  while (firstModule != NULL) {
+    firstModule = freeExternalModule(firstModule);
   }
-  return initExtraModules(basePath, MODULE_COUNT(ata_modules), ata_modules);
-}
-
-int initMX4SIO(char *basePath) {
-  int res = 0;
-  if ((res = initExtraModules(basePath, MODULE_COUNT(bdm_base_modules), bdm_base_modules))) {
-    return res;
-  }
-  return initExtraModules(basePath, MODULE_COUNT(mx4sio_modules), mx4sio_modules);
-}
-
-int initUDPBD(char *basePath, char *hostIPAddr) {
-  if (strlen(hostIPAddr) == 0) {
-    logString("ERROR: invalid IP address length\n");
-    return -EINVAL;
-  }
-
-  int ret = 0;
-  if ((ret = initExtraModules(basePath, MODULE_COUNT(bdm_base_modules), bdm_base_modules))) {
-    return ret;
-  }
-
-  // Treating last module as a special case because it needs an argument to work
-  if ((ret = initExtraModules(basePath, MODULE_COUNT(udpbd_modules) - 1, udpbd_modules))) {
-    return ret;
-  }
-
-  // Allocate memory for module path and argument
-  int iopret;
-  char pathBuf[PATH_MAX + 1];
-  pathBuf[0] = '\0';
-  strcpy(pathBuf, basePath);
-  char ipArg[19]; // 15 bytes for IP string + 3 bytes for 'ip='
-  snprintf(ipArg, sizeof(ipArg), "ip=%s", hostIPAddr);
-
-  // Append module path to base path
-  strcat(pathBuf, udpbd_modules[MODULE_COUNT(udpbd_modules) - 1]);
-  logString("\tloading %s\n\twith %s\n", pathBuf, ipArg);
-  ret = SifLoadStartModule(pathBuf, sizeof(ipArg), ipArg, &iopret);
-  if (ret < 0) {
-    return ret;
-  }
-  if (iopret == 1) {
-    return iopret;
-  }
-  return 0;
-}
-
-int initUSB(char *basePath) {
-  int res = 0;
-  if ((res = initExtraModules(basePath, MODULE_COUNT(bdm_base_modules), bdm_base_modules))) {
-    return res;
-  }
-  return initExtraModules(basePath, MODULE_COUNT(usb_modules), usb_modules);
-}
-
-// Initializes BDM modules depending on launcher mode
-int initBDM(char *basePath) {
-  switch (LAUNCHER_OPTIONS.mode) {
-  case MODE_MX4SIO:
-    return initMX4SIO(ELF_BASE_PATH);
-  case MODE_UDPBD:
-    return initUDPBD(ELF_BASE_PATH, LAUNCHER_OPTIONS.udpbdIp);
-  case MODE_USB:
-    return initUSB(ELF_BASE_PATH);
-  default:
-    return initATA(ELF_BASE_PATH);
-  }
+  return NULL;
 }


### PR DESCRIPTION
This PR improves initialization process for external modules:
- All external modules are now contained in the same list
- An argument generator function type is introduced to remove the need for special handling of modules with arguments; both module types (with and without arguments) are now loaded using the same function.
- Modules are pre-loaded into EE RAM before the IOP reset, allowing NHDDL to load from any device, including `host:` via PS2Link.

Additional changes:
- If neutrino.elf is not found in the current directory, fallback paths (`mc%d:/APPS/neutrino/neutrino.elf` and `mass%d:/neutrino/neutrino.elf`) are used instead.