### PR TITLE
Improve module initialization, add iLink support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ GSM, PADEMU, IGR and other stuff is out-of-scope of this launcher.
 - Get the [latest `nhddl.elf`](https://github.com/pcm720/nhddl/releases)
 - Unpack Neutrino release
 - Copy `nhddl.elf` to Neutrino folder next to `neutrino.elf`
-- _Additional step if you need USB, MX4SIO or UDPBD_:  
+- _Additional step if you need only ATA, USB, MX4SIO or UDPBD_:  
   Modify `nhddl.yaml` [accordingly](#common-use-cases) and copy it next to `nhddl.elf`
 - Copy Neutrino folder to your PS2 memory card.  
   Any folder (e.g. `APPS`) will do, it doesn't have to be in the root of your memory card.
@@ -25,21 +25,22 @@ Updating `nhddl.elf` is as simple as replacing `nhddl.elf` with the latest versi
 ### Supported BDM devices
 
 NHDDL reuses Neutrino modules for BDM support and requires them to be present in Neutrino `modules` directory.
-These files should already be present in Neutrino release ZIP by default.
+These files should already be present in Neutrino release ZIP.
 
-By default, NHDDL initializes ATA modules and looks for ISOs on internal FAT/exFAT-formatted HDD, devices other than ATA require additional configuration.  
+By default, NHDDL initializes all modules and looks for ISOs on FAT/exFAT-formatted BDM devices.  
 See [this](#launcher-configuration-file) section for details on `nhddl.yml`.
 
 **Do not plug in any USB mass storage devices while running NHDDL!**  
 Doing so might crash NHDDL and/or possibly corrupt the files on your target device due to how BDM drivers work.
 
 #### ATA
-This is the default device mode.  
 Make sure that Neutrino `modules` directory contains the following IRX files:
 - `bdm.irx` 
 - `bdmfs_fatfs.irx`
 - `dev9_ns.irx`
 - `ata_bd.irx`
+
+To skip all other BDM devices, `mode: ata` must be present in `nhddl.yaml`.
 
 #### MX4SIO
 The following files are required for MX4SIO:
@@ -47,7 +48,7 @@ The following files are required for MX4SIO:
 - `bdmfs_fatfs.irx`
 - `mx4sio_bd_mini.irx`
 
-`mode: mx4sio` must be present in `nhddl.yaml`.
+To skip all other BDM devices, `mode: mx4sio` must be present in `nhddl.yaml` to initialize only MX4SIO.
 
 #### USB
 The following files are required for USB:
@@ -56,7 +57,7 @@ The following files are required for USB:
 - `usbd_mini.irx`
 - `usbmass_bd_mini.irx`
 
-`mode: usb` must be present in `nhddl.yaml`.
+To skip all other BDM devices, `mode: usb` must be present in `nhddl.yaml`.
 
 #### UDPBD
 The following files are required for UDPBD:
@@ -65,7 +66,7 @@ The following files are required for UDPBD:
 - `dev9_ns.irx`
 - `smap_udpbd.irx`
 
-`mode: udpbd` must be present in `nhddl.yaml`.
+To skip all other BDM devices, `mode: udpbd` must be present in `nhddl.yaml`.
 
 UDPBD module requires PS2 IP address to work.  
 NHDDL attempts to retrieve PS2 IP address from the following sources:
@@ -73,6 +74,15 @@ NHDDL attempts to retrieve PS2 IP address from the following sources:
 - `SYS-CONF/IPCONFIG.DAT` on the memory card (usually created by w/uLaunchELF)
 
 `udpbd_ip` flag takes priority over `IPCONFIG.DAT`.
+
+#### iLink
+The following files are required for iLink:
+- `bdm.irx` 
+- `bdmfs_fatfs.irx`
+- `iLinkman.irx`
+- `IEEE1394_bd_mini.irx`
+
+To skip all other BDM devices, `mode: ilink` must be present in `nhddl.yaml`.
 
 ### Storing ISO
 
@@ -102,7 +112,7 @@ NHDDL uses YAML-like files to load and store its configuration options.
 
 Launcher configuration is read from the `nhddl.yaml` file, which must be located in the same directory as `nhddl.elf`.  
 This file is _completely optional_ and must be used only to enable 480p in NHDDL UI or switch NHDDL mode to something other than `ata`.  
-By default, 480p is disabled and the ATA device is used to look for ISO files.
+By default, 480p is disabled and the all devices are used to look for ISO files.
 
 To disable a flag, you can just comment it out with `#`.
 

--- a/examples/nhddl.yaml
+++ b/examples/nhddl.yaml
@@ -1,3 +1,3 @@
 #480p: # uncomment to enable 480p in NHDDL UI
-mode: ata # supported modes: ata (default), mx4sio, udpbd, usb
+mode: ata # supported modes: ata, mx4sio, udpbd, usb, ilink
 #udpbd_ip: 192.168.1.6 # PS2 IP address for UDPBD mode (commented out)

--- a/include/common.h
+++ b/include/common.h
@@ -5,10 +5,12 @@
 
 // Enum for supported modes
 typedef enum {
+  MODE_ALL,
   MODE_ATA,
   MODE_MX4SIO,
   MODE_UDPBD,
-  MODE_USB
+  MODE_USB,
+  MODE_ILINK
 } ModeType;
 
 // Launcher options

--- a/src/main.c
+++ b/src/main.c
@@ -119,7 +119,9 @@ ModeType parseMode(const char *modeStr) {
     return MODE_UDPBD;
   if (!strcmp(modeStr, "usb"))
     return MODE_USB;
-  return MODE_ATA;
+  if (!strcmp(modeStr, "ilink"))
+    return MODE_ILINK;
+  return MODE_ALL;
 }
 
 // Tries to read SYS-CONF/IPCONFIG.DAT from basePath
@@ -157,7 +159,7 @@ void parseIPConfig(LauncherOptions *opts) {
 // Loads NHDDL options from optionsFile on memory card
 void initOptions(char *basePath) {
   LAUNCHER_OPTIONS.is480pEnabled = 0;
-  LAUNCHER_OPTIONS.mode = MODE_ATA;
+  LAUNCHER_OPTIONS.mode = MODE_ALL;
   LAUNCHER_OPTIONS.udpbdIp[0] = '\0';
 
   char lineBuffer[PATH_MAX + sizeof(optionsFile) + 1];

--- a/src/module_init.c
+++ b/src/module_init.c
@@ -37,8 +37,7 @@ typedef struct ExternalModule {
   u32 size;           // IRX size
   u32 argLength;      // Argument string length
   char *argStr;       // Argument string
-  int canFail;        // Indicates if module can fail to load
-  ModeType mode;                  // Used to ignore modules not required for target mode
+  ModeType mode;      // Used to ignore modules not required for target mode
 
   struct ExternalModule *next; // Next module in the list
 } ExternalModule;
@@ -58,7 +57,6 @@ typedef struct ExternalModuleEntry {
   char *name;                     // Module name
   char *path;                     // Relative path to module
   moduleArgFunc argumentFunction; // Function used to initialize module arguments
-  int canFail;                    // If not zero, module failing to load will not be considered a critical error
   ModeType mode;                  // Used to ignore modules not required for target mode
 } ExternalModuleEntry;
 
@@ -68,25 +66,25 @@ int initSMAPArguments(ExternalModule *mod);
 #define MODULE_COUNT(a) sizeof(a) / sizeof(ExternalModuleEntry)
 const ExternalModuleEntry external_modules[] = {
     // DEV9
-    {"dev9", "modules/dev9_ns.irx", NULL, 0, MODE_ALL},
+    {"dev9", "modules/dev9_ns.irx", NULL, MODE_ALL},
     // BDM
-    {"bdm", "modules/bdm.irx", NULL, 0, MODE_ALL},
+    {"bdm", "modules/bdm.irx", NULL, MODE_ALL},
     // FAT/exFAT
-    {"bdmfs_fatfs", "modules/bdmfs_fatfs.irx", NULL, 0, MODE_ALL},
+    {"bdmfs_fatfs", "modules/bdmfs_fatfs.irx", NULL, MODE_ALL},
     // ATA
-    {"ata_bd", "modules/ata_bd.irx", NULL, 1, MODE_ATA},
+    {"ata_bd", "modules/ata_bd.irx", NULL, MODE_ATA},
     // USBD
-    {"usbd_mini", "modules/usbd_mini.irx", NULL, 1, MODE_USB},
+    {"usbd_mini", "modules/usbd_mini.irx", NULL, MODE_USB},
     // USB Mass Storage
-    {"usbmass_bd_mini", "modules/usbmass_bd_mini.irx", NULL, 1, MODE_USB},
+    {"usbmass_bd_mini", "modules/usbmass_bd_mini.irx", NULL, MODE_USB},
     // MX4SIO
-    {"mx4sio_bd_mini", "modules/mx4sio_bd_mini.irx", NULL, 1, MODE_MX4SIO},
+    {"mx4sio_bd_mini", "modules/mx4sio_bd_mini.irx", NULL, MODE_MX4SIO},
     // SMAP driver. Actually includes small IP stack and UDPTTY
-    {"smap_udpbd", "modules/smap_udpbd.irx", &initSMAPArguments, 1, MODE_UDPBD},
+    {"smap_udpbd", "modules/smap_udpbd.irx", &initSMAPArguments, MODE_UDPBD},
     // iLink
-    {"iLinkman", "modules/iLinkman.irx", NULL, 1, MODE_ILINK},
+    {"iLinkman", "modules/iLinkman.irx", NULL, MODE_ILINK},
     // iLink Mass Storage
-    {"IEEE1394_bd_mini", "modules/IEEE1394_bd_mini.irx", NULL, 1, MODE_ILINK},
+    {"IEEE1394_bd_mini", "modules/IEEE1394_bd_mini.irx", NULL, MODE_ILINK},
 };
 
 // Initializes IOP modules
@@ -132,7 +130,7 @@ int init_modules(char *basePath) {
 
     ret = SifExecModuleBuffer(modules->irx, modules->size, modules->argLength, modules->argStr, &iopret);
     // Ignore error if module can fail
-    if (!modules->canFail || (modules->mode == LAUNCHER_OPTIONS.mode)) {
+    if ((modules->mode == MODE_ALL) || (modules->mode == LAUNCHER_OPTIONS.mode)) {
       if (ret < 0)
         return ret;
       if (iopret == 1)
@@ -192,7 +190,7 @@ ExternalModule *buildExternalModuleList(char *basePath) {
     // Open module
     if ((fd = open(pathBuf, O_RDONLY)) < 0) {
       logString("%s: Failed to open %s\n", external_modules[i].name, pathBuf);
-      if (!external_modules[i].canFail)
+      if ((external_modules[i].mode == MODE_ALL) || (external_modules[i].mode == LAUNCHER_OPTIONS.mode))
         goto fail;
       continue;
     }
@@ -223,7 +221,6 @@ ExternalModule *buildExternalModuleList(char *basePath) {
     mod->name = external_modules[i].name;
     mod->irx = irxBuf;
     mod->size = fsize;
-    mod->canFail = external_modules[i].canFail;
     mod->mode = external_modules[i].mode;
 
     // If module has an arugment function, execute it
@@ -233,7 +230,7 @@ ExternalModule *buildExternalModuleList(char *basePath) {
         free(irxBuf);
         free(mod);
         // Ignore errors if module can fail
-        if (external_modules[i].canFail && (external_modules[i].mode != LAUNCHER_OPTIONS.mode)) {
+        if ((external_modules[i].mode != MODE_ALL) && (external_modules[i].mode != LAUNCHER_OPTIONS.mode)) {
           logString("\t%s: Failed to initialize arguments, skipping module\n", external_modules[i].name);
           continue;
         } else {

--- a/src/module_init.c
+++ b/src/module_init.c
@@ -38,6 +38,7 @@ typedef struct ExternalModule {
   u32 argLength;      // Argument string length
   char *argStr;       // Argument string
   int canFail;        // Indicates if module can fail to load
+  ModeType mode;                  // Used to ignore modules not required for target mode
 
   struct ExternalModule *next; // Next module in the list
 } ExternalModule;
@@ -58,6 +59,7 @@ typedef struct ExternalModuleEntry {
   char *path;                     // Relative path to module
   moduleArgFunc argumentFunction; // Function used to initialize module arguments
   int canFail;                    // If not zero, module failing to load will not be considered a critical error
+  ModeType mode;                  // Used to ignore modules not required for target mode
 } ExternalModuleEntry;
 
 // Initializes SMAP arguments
@@ -66,27 +68,25 @@ int initSMAPArguments(ExternalModule *mod);
 #define MODULE_COUNT(a) sizeof(a) / sizeof(ExternalModuleEntry)
 const ExternalModuleEntry external_modules[] = {
     // DEV9
-    {"dev9", "modules/dev9_ns.irx", NULL, 0},
+    {"dev9", "modules/dev9_ns.irx", NULL, 0, MODE_ALL},
     // BDM
-    {"bdm", "modules/bdm.irx", NULL, 0},
-    // Required for getting title ID from ISO
-    {"isofs", "modules/isofs.irx", NULL, 0},
+    {"bdm", "modules/bdm.irx", NULL, 0, MODE_ALL},
     // FAT/exFAT
-    {"bdmfs_fatfs", "modules/bdmfs_fatfs.irx", NULL, 0},
+    {"bdmfs_fatfs", "modules/bdmfs_fatfs.irx", NULL, 0, MODE_ALL},
     // ATA
-    {"ata_bd", "modules/ata_bd.irx", NULL, 1},
+    {"ata_bd", "modules/ata_bd.irx", NULL, 1, MODE_ATA},
     // USBD
-    {"usbd_mini", "modules/usbd_mini.irx", NULL, 1},
+    {"usbd_mini", "modules/usbd_mini.irx", NULL, 1, MODE_USB},
     // USB Mass Storage
-    {"usbmass_bd_mini", "modules/usbmass_bd_mini.irx", NULL, 1},
+    {"usbmass_bd_mini", "modules/usbmass_bd_mini.irx", NULL, 1, MODE_USB},
     // MX4SIO
-    {"mx4sio_bd_mini", "modules/mx4sio_bd_mini.irx", NULL, 1},
+    {"mx4sio_bd_mini", "modules/mx4sio_bd_mini.irx", NULL, 1, MODE_MX4SIO},
     // SMAP driver. Actually includes small IP stack and UDPTTY
-    {"smap_udpbd", "modules/smap_udpbd.irx", &initSMAPArguments, 1},
+    {"smap_udpbd", "modules/smap_udpbd.irx", &initSMAPArguments, 1, MODE_UDPBD},
     // iLink
-    // {"iLinkman", "modules/iLinkman.irx", NULL, 1},
+    {"iLinkman", "modules/iLinkman.irx", NULL, 1, MODE_ILINK},
     // iLink Mass Storage
-    // {"IEEE1394_bd_mini", "modules/IEEE1394_bd_mini.irx", NULL, 1},
+    {"IEEE1394_bd_mini", "modules/IEEE1394_bd_mini.irx", NULL, 1, MODE_ILINK},
 };
 
 // Initializes IOP modules
@@ -94,7 +94,8 @@ int init_modules(char *basePath) {
   // Load optional modules into EE memory before resetting IOP
   ExternalModule *modules = buildExternalModuleList(basePath);
   if (modules == NULL) {
-    logString("WARN: No external modules will be loaded\n");
+    logString("ERROR: Failed to prepare external modules\n");
+    return -EIO;
   }
 
   // Initialize the RPC manager and reset IOP
@@ -131,7 +132,7 @@ int init_modules(char *basePath) {
 
     ret = SifExecModuleBuffer(modules->irx, modules->size, modules->argLength, modules->argStr, &iopret);
     // Ignore error if module can fail
-    if (!modules->canFail) {
+    if (!modules->canFail || (modules->mode == LAUNCHER_OPTIONS.mode)) {
       if (ret < 0)
         return ret;
       if (iopret == 1)
@@ -175,6 +176,13 @@ ExternalModule *buildExternalModuleList(char *basePath) {
   ExternalModule *firstModule = NULL;
   int fd, fsize, res;
   for (int i = 0; i < MODULE_COUNT(external_modules); i++) {
+    // Ignore module if:
+    if (external_modules[i].mode != LAUNCHER_OPTIONS.mode && // Target mode doesn't match required mode
+        external_modules[i].mode != MODE_ALL &&              // Module is not required
+        LAUNCHER_OPTIONS.mode != MODE_ALL) {                 // Target mode is not set to ALL
+      continue;
+    }
+
     // End bufferred string at basePath for the next strcat in the loop
     pathBuf[basePathLen] = '\0';
 
@@ -216,6 +224,7 @@ ExternalModule *buildExternalModuleList(char *basePath) {
     mod->irx = irxBuf;
     mod->size = fsize;
     mod->canFail = external_modules[i].canFail;
+    mod->mode = external_modules[i].mode;
 
     // If module has an arugment function, execute it
     if (external_modules[i].argumentFunction != NULL) {
@@ -224,7 +233,7 @@ ExternalModule *buildExternalModuleList(char *basePath) {
         free(irxBuf);
         free(mod);
         // Ignore errors if module can fail
-        if (external_modules[i].canFail) {
+        if (external_modules[i].canFail && (external_modules[i].mode != LAUNCHER_OPTIONS.mode)) {
           logString("\t%s: Failed to initialize arguments, skipping module\n", external_modules[i].name);
           continue;
         } else {


### PR DESCRIPTION
This PR adds support for iLink mode and introduces "all" mode to enable supporting all BDM devices at once.

This PR also fixes issues in refactored module initialization by:
- Specifying modes for external modules
- Ignoring modules not required for target mode
- Handling initialization errors for modules actually needed for the target mode to work