### PR TITLE
Support for scanning multiple BDM devices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ EE_BIN_PKD = $(ELF_BASE_NAME).elf
 EE_BIN_DEBUG := $(ELF_BASE_NAME)-debug_unc.elf
 EE_BIN_DEBUG_PKD := $(ELF_BASE_NAME)-debug.elf
 
-EE_OBJS = main.o module_init.o common.o iso.o history.o options.o gui.o pad.o launcher.o iso_cache.o iso_title_id.o
+EE_OBJS = main.o module_init.o common.o iso.o history.o options.o gui.o pad.o launcher.o iso_cache.o iso_title_id.o devices.o
 IRX_FILES += sio2man.irx mcman.irx mcserv.irx fileXio.irx iomanX.irx freepad.irx
 RES_FILES += icon_A.sys icon_C.sys icon_J.sys
 ELF_FILES += loader.elf

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NHDDL — a PS2 exFAT BDM launcher for Neutrino
 
-NHDDL is a memory card-based launcher that scans _FAT/exFAT-formatted_ BDM devices for ISO files,
+NHDDL is a Neutrino launcher that scans _FAT/exFAT-formatted_ BDM devices for ISO files,
 lists them and boots selected ISO via Neutrino.  
 
 It displays visual Game ID to trigger per-game settings on the Pixel FX line of products and writes to memory card history file before launching the title, triggering per-title memory cards on SD2PSX and MemCard PRO 2.
@@ -17,10 +17,13 @@ GSM, PADEMU, IGR, IGS and other stuff is out-of-scope of this launcher.
 - Copy `nhddl.elf` to Neutrino folder next to `neutrino.elf`
 - _Additional step if you need only ATA, USB, MX4SIO, UDPBD or iLink_:  
   Modify `nhddl.yaml` [accordingly](#common-use-cases) and copy it next to `nhddl.elf`
-- Copy Neutrino folder to your PS2 memory card.  
-  Any folder (e.g. `APPS`) will do, it doesn't have to be in the root of your memory card.
+- Copy Neutrino folder to your PS2 memory card or your USB device.  
+  Any folder (e.g. `APPS`) will do, it doesn't have to be in the root of your device.
 
 Updating `nhddl.elf` is as simple as replacing `nhddl.elf` with the latest version.
+
+If you're getting `Failed to prepare external modules` error while trying to run NHDDL from the USB drive, make sure your ELF launcher initializes
+USB modules and doesn't reset the IOP before loading NHDDL.
 
 ### Supported BDM devices
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It displays visual Game ID to trigger per-game settings on the Pixel FX line of 
 
 Note that this not an attempt at making a Neutrino-based Open PS2 Loader replacement.  
 It __will not__ boot ISOs from anything other than BDM devices.  
-GSM, PADEMU, IGR and other stuff is out-of-scope of this launcher.
+GSM, PADEMU, IGR, IGS and other stuff is out-of-scope of this launcher.
 
 ## Usage
 
@@ -15,7 +15,7 @@ GSM, PADEMU, IGR and other stuff is out-of-scope of this launcher.
 - Get the [latest `nhddl.elf`](https://github.com/pcm720/nhddl/releases)
 - Unpack Neutrino release
 - Copy `nhddl.elf` to Neutrino folder next to `neutrino.elf`
-- _Additional step if you need only ATA, USB, MX4SIO or UDPBD_:  
+- _Additional step if you need only ATA, USB, MX4SIO, UDPBD or iLink_:  
   Modify `nhddl.yaml` [accordingly](#common-use-cases) and copy it next to `nhddl.elf`
 - Copy Neutrino folder to your PS2 memory card.  
   Any folder (e.g. `APPS`) will do, it doesn't have to be in the root of your memory card.
@@ -57,6 +57,7 @@ The following files are required for USB:
 - `usbd_mini.irx`
 - `usbmass_bd_mini.irx`
 
+Using more than one USB mass storage device at the same time is not recommended.
 To skip all other BDM devices, `mode: usb` must be present in `nhddl.yaml`.
 
 #### UDPBD
@@ -122,7 +123,7 @@ See [this file](examples/nhddl.yaml) for an example of a valid `nhddl.yaml` file
 
 NHDDL stores and looks for ISO-related config files in `nhddl` directory in the root of your BDM drive.  
 
-#### `lastTitle.txt`
+#### `lastTitle.bin`
 
 This file stores the full path of the last launched title and is used to automatically navigate to it each time NHDDL starts up.  
 This file is created automatically.
@@ -143,8 +144,8 @@ Example of a valid argument file:
 ```yaml
 # All flags are passed to neutrino as-is for future-proofing, comments are ignored
 gc: 2
-mc0: mass:/memcard0.bin # all file paths must always start with mass:
-$mc1: mass:/memcard1.bin # this argument is disabled
+mc0: massX:/memcard0.bin # all file paths must always start with massX:. X will be replaced with the actual device number.
+$mc1: massX:/memcard1.bin # this argument is disabled
 # Arguments that don't have a value
 # Empty values are treated as a simple flag
 dbc:
@@ -190,25 +191,33 @@ DVD/
 
 ## Common use cases
 
-### Switching NHDDL to USB mode
+### Switching NHDDL to ATA-only mode
 
-To switch NHDDL to USB mode, you'll need to create `nhddl.yaml` with the following contents:
+To switch NHDDL to ATA-only mode, you'll need to create `nhddl.yaml` with the following contents:
+```yaml
+mode: ata
+```
+Copy this file to Neutrino directory next to `nhddl.elf`.
+
+### Switching NHDDL to USB-only mode
+
+To switch NHDDL to USB-only mode, you'll need to create `nhddl.yaml` with the following contents:
 ```yaml
 mode: usb
 ```
 Copy this file to Neutrino directory next to `nhddl.elf`.
 
-### Switching NHDDL to MX4SIO mode
+### Switching NHDDL to MX4SIO-only mode
 
-To switch NHDDL to MX4SIO mode, you'll need to create `nhddl.yaml` with the following contents:
+To switch NHDDL to MX4SIO-only mode, you'll need to create `nhddl.yaml` with the following contents:
 ```yaml
 mode: mx4sio
 ```
 Copy this file to Neutrino directory next to `nhddl.elf`.
 
-### Switching NHDDL to UDPBD mode
+### Switching NHDDL to UDPBD-only mode
 
-To switch NHDDL to UDPBD mode, you'll need to create `nhddl.yaml` with the following contents:
+To switch NHDDL to UDPBD-only mode, you'll need to create `nhddl.yaml` with the following contents:
 ```yaml
 mode: udpbd
 udpbd_ip: <PS2 IP address>
@@ -218,6 +227,14 @@ If you've previously set up the network via uLaunchELF and your memory card
 has `SYS-CONF/IPCONFIG.DAT` file, you don't have to add `udpbd_ip`.
 
 Copy this file to the Neutrino directory next to `nhddl.elf`.
+
+### Switching NHDDL to iLink-only mode
+
+To switch NHDDL to iLink-only mode, you'll need to create `nhddl.yaml` with the following contents:
+```yaml
+mode: ilink
+```
+Copy this file to Neutrino directory next to `nhddl.elf`.
 
 ## UI screenshots
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ NHDDL uses YAML-like files to load and store its configuration options.
 ### Launcher configuration file
 
 Launcher configuration is read from the `nhddl.yaml` file, which must be located in the same directory as `nhddl.elf`.  
-This file is _completely optional_ and must be used only to enable 480p in NHDDL UI or switch NHDDL mode to something other than `ata`.  
+This file is _completely optional_ and must be used only to enable 480p in NHDDL UI or switch NHDDL to single device.  
 By default, 480p is disabled and the all devices are used to look for ISO files.
 
 To disable a flag, you can just comment it out with `#`.

--- a/examples/nhddl.yaml
+++ b/examples/nhddl.yaml
@@ -1,3 +1,3 @@
 #480p: # uncomment to enable 480p in NHDDL UI
-mode: ata # supported modes: ata, mx4sio, udpbd, usb, ilink
+mode: ata # supported modes: ata, mx4sio, udpbd, usb, ilink. If not present or commented out, all devices will be used to search for ISO files
 #udpbd_ip: 192.168.1.6 # PS2 IP address for UDPBD mode (commented out)

--- a/include/common.h
+++ b/include/common.h
@@ -20,8 +20,6 @@ typedef struct {
   char udpbdIp[16];
 } LauncherOptions;
 
-// Maximum size of storage mountpoint (massX:) without the null-terminator
-#define MAX_STORAGE_BASE_PATH_LEN 6 
 // ELF base path. Initialized in main() during init.
 extern char ELF_BASE_PATH[PATH_MAX + 1];
 // Path to Neutrino ELF. Initialized in main() during init.

--- a/include/common.h
+++ b/include/common.h
@@ -20,9 +20,8 @@ typedef struct {
   char udpbdIp[16];
 } LauncherOptions;
 
-// Storage device base path. Initialized in main.c
-extern const char STORAGE_BASE_PATH[];
-extern const size_t STORAGE_BASE_PATH_LEN;
+// Maximum size of storage mountpoint (massX:) without the null-terminator
+#define MAX_STORAGE_BASE_PATH_LEN 6 
 // ELF base path. Initialized in main() during init.
 extern char ELF_BASE_PATH[PATH_MAX + 1];
 // Path to Neutrino ELF. Initialized in main() during init.
@@ -32,5 +31,7 @@ extern LauncherOptions LAUNCHER_OPTIONS;
 
 // Logs to screen and debug console
 void logString(const char *str, ...);
+// Maps ModeType to string
+char *modeToString(ModeType mode);
 
 #endif

--- a/include/devices.h
+++ b/include/devices.h
@@ -1,0 +1,23 @@
+#ifndef _DEVICES_H_
+#define _DEVICES_H_
+
+#include "common.h"
+
+#define MAX_MASS_DEVICES 10
+
+#define MASS_PLACEHOLDER "massX:"
+
+// Device map entry
+typedef struct {
+  ModeType mode;
+  int index;
+} DeviceMapEntry;
+
+// Maps BDM device index (massX:) to supported mode.
+// Device must be ignored if mode is MODE_ALL
+extern DeviceMapEntry deviceModeMap[];
+
+// Initializes device mode map
+int initDeviceMap();
+
+#endif

--- a/include/devices.h
+++ b/include/devices.h
@@ -6,6 +6,7 @@
 #define MAX_MASS_DEVICES 10
 
 #define MASS_PLACEHOLDER "massX:"
+#define MASS_PLACEHOLDER_LEN sizeof(MASS_PLACEHOLDER)/sizeof(char)
 
 // Device map entry
 typedef struct {
@@ -17,7 +18,7 @@ typedef struct {
 // Device must be ignored if mode is MODE_ALL
 extern DeviceMapEntry deviceModeMap[];
 
-// Initializes device mode map
+// Initializes device mode map and returns device count
 int initDeviceMap();
 
 #endif

--- a/include/iso.h
+++ b/include/iso.h
@@ -1,14 +1,16 @@
 #ifndef _ISO_H_
 #define _ISO_H_
 
+#include "common.h"
 #include <stdint.h>
 
 // An entry in TargetList
 typedef struct Target {
-  uint16_t idx;   // ISO index (monotonically increasing). Used to uniquely identify the list entry
-  char *fullPath; // Full path to ISO
-  char *name;     // Target name (extracted from file name)
-  char *id;       // Title ID
+  uint16_t idx;        // ISO index (monotonically increasing). Used to uniquely identify the list entry
+  char *fullPath;      // Full path to ISO
+  char *name;          // Target name (extracted from file name)
+  char *id;            // Title ID
+  ModeType deviceType; // Device type
 
   struct Target *prev; // Previous target in the list
   struct Target *next; // Next target in the list
@@ -16,12 +18,12 @@ typedef struct Target {
 
 // A linked list of launch candidates
 typedef struct {
-  int total;            // Total number of targets
+  int total;     // Total number of targets
   Target *first; // First target
   Target *last;  // Last target
 } TargetList;
 
-// Generates a list of launch candidates found in STORAGE_BASE_PATH
+// Generates a list of launch candidates found on BDM devices
 TargetList *findISO();
 
 // Completely frees TargetList. Passed pointer will not be valid after this function executes

--- a/include/options.h
+++ b/include/options.h
@@ -5,7 +5,7 @@
 #include <ps2sdkapi.h>
 
 
-// Location of configuration directory relative to STORAGE_BASE_PATH
+// Location of configuration directory relative to storage mountpoint
 extern const char BASE_CONFIG_PATH[];
 extern const size_t BASE_CONFIG_PATH_LEN;
 
@@ -45,17 +45,18 @@ typedef struct {
 
 // Writes full path to targetFileName into targetPath.
 // If targetFileName is NULL, will return path to config directory
-void buildConfigFilePath(char *targetPath, const char *targetFileName);
-
-// Sets last launched title path in global config
-int updateLastLaunchedTitle(char *titlePath);
+void buildConfigFilePath(char *targetPath, const char *targetMountpoint, const char *targetFileName);
 
 // Gets last launched title path into titlePath
+// Searches for the latest file across all mounted BDM devices
 int getLastLaunchedTitle(char *titlePath);
 
-// Generates ArgumentList from global config file.
+// Writes last launched title path into lastTitle file on title mountpoint
+int updateLastLaunchedTitle(char *titlePath);
+
+// Generates ArgumentList from global config file located at targetMounpoint (usually ISO full path)
 // Will reinitialize result without clearing existing contents. On error, result will contain invalid pointer.
-int getGlobalLaunchArguments(ArgumentList *result);
+int getGlobalLaunchArguments(ArgumentList *result, const char *targetMountpoint);
 
 // Generates ArgumentList from title-specific config file.
 // Will reinitialize result without clearing existing contents. On error, result will contain invalid pointer.

--- a/src/common.c
+++ b/src/common.c
@@ -1,3 +1,4 @@
+#include "common.h"
 #include <debug.h>
 #include <stdio.h>
 
@@ -10,4 +11,22 @@ void logString(const char *str, ...) {
   scr_vprintf(str, args);
 
   va_end(args);
+}
+
+// Maps ModeType to string
+char *modeToString(ModeType mode) {
+  switch (mode) {
+  case MODE_ATA:
+    return "ATA";
+  case MODE_MX4SIO:
+    return "MX4SIO";
+  case MODE_UDPBD:
+    return "UDPBD";
+  case MODE_USB:
+    return "USB";
+  case MODE_ILINK:
+    return "iLink";
+  default:
+    return "Unknown";
+  }
 }

--- a/src/devices.c
+++ b/src/devices.c
@@ -1,0 +1,97 @@
+#include "devices.h"
+#include "common.h"
+#include <errno.h>
+#include <kernel.h>
+#include <stdio.h>
+#include <string.h>
+#include <usbhdfsd-common.h>
+
+// Used to get BDM driver name
+#define NEWLIB_PORT_AWARE
+#include <fileXio_rpc.h>
+#include <io_common.h>
+
+// Maps mass device index to supported mode.
+// Device must be ignored if mode is MODE_ALL
+DeviceMapEntry deviceModeMap[MAX_MASS_DEVICES] = {};
+
+// Maps driver name to ModeType
+ModeType mapDriverName(char *driverName) {
+  if (!strncmp(driverName, "ata", 3))
+    return MODE_ATA;
+  else if (!strncmp(driverName, "sdc", 3))
+    return MODE_MX4SIO;
+  else if (!strncmp(driverName, "usb", 3))
+    return MODE_USB;
+  else if (!strncmp(driverName, "sd", 2))
+    return MODE_ILINK;
+  else if (!strncmp(driverName, "udp", 3))
+    return MODE_UDPBD;
+  return MODE_ALL;
+}
+
+//
+// The following functions are based on code by AKuHAK
+//
+
+void delay(int count) {
+  int ret;
+  for (int i = 0; i < count; i++) {
+    ret = 0x01000000;
+    while (ret--)
+      asm("nop\nnop\nnop\nnop");
+  }
+}
+
+// Gets BDM driver name via fileXio
+int getDeviceDriver(char *mountpoint, DeviceMapEntry *entry) {
+  int fd = fileXioDopen(mountpoint);
+  if (fd < 0) {
+    return -ENODEV;
+  }
+
+  char driverName[10];
+  int deviceNumber;
+  if (fileXioIoctl2(fd, USBMASS_IOCTL_GET_DRIVERNAME, NULL, 0, driverName, sizeof(driverName) - 1) >= 0) {
+    // Null-terminate the string before mapping
+    driverName[sizeof(driverName) - 1] = '\0';
+    entry->mode = mapDriverName(driverName);
+  }
+
+  // Get device number
+  if (fileXioIoctl2(fd, USBMASS_IOCTL_GET_DEVICE_NUMBER, NULL, 0, &deviceNumber, sizeof(deviceNumber)) >= 0)
+    entry->index = deviceNumber;
+
+  fileXioDclose(fd);
+  return 0;
+}
+
+// Initializes device mode map
+int initDeviceMap() {
+  DIR *directory;
+  char mountpoint[] = MASS_PLACEHOLDER;
+
+  for (int i = 0; i < MAX_MASS_DEVICES; i++) {
+    mountpoint[4] = i + '0';
+    // Wait for IOP to initialize device driver
+    for (int i = 0; i < 2; i++) {
+      delay(2);
+      directory = opendir(mountpoint);
+      if (directory != NULL) {
+        closedir(directory);
+        break;
+      }
+    }
+    if (directory == NULL) {
+      // Since BDM devices are always mounted sequentially,
+      // non-exiting mountpoint means that there will be no more devices
+      break;
+    }
+
+    if (getDeviceDriver(mountpoint, &deviceModeMap[i]) < 0) {
+      printf("ERROR: failed to get driver for device %s\n", mountpoint);
+      return -EIO;
+    }
+  }
+  return 0;
+}

--- a/src/devices.c
+++ b/src/devices.c
@@ -72,10 +72,16 @@ int initDeviceMap() {
   char mountpoint[] = MASS_PLACEHOLDER;
 
   int deviceCount = 0;
+  int delayAttempts = 2;
+  if ((LAUNCHER_OPTIONS.mode == MODE_ALL) || (LAUNCHER_OPTIONS.mode == MODE_UDPBD)) {
+    // UDPBD needs considerably more time to init
+    delayAttempts = 10;
+  }
   for (int i = 0; i < MAX_MASS_DEVICES; i++) {
     mountpoint[4] = i + '0';
+
     // Wait for IOP to initialize device driver
-    for (int wait = 0; wait < 2; wait++) {
+    for (int attempts = 0; attempts < delayAttempts; attempts++) {
       delay(2);
       directory = opendir(mountpoint);
       if (directory != NULL) {

--- a/src/devices.c
+++ b/src/devices.c
@@ -66,15 +66,16 @@ int getDeviceDriver(char *mountpoint, DeviceMapEntry *entry) {
   return 0;
 }
 
-// Initializes device mode map
+// Initializes device mode map and returns device count
 int initDeviceMap() {
   DIR *directory;
   char mountpoint[] = MASS_PLACEHOLDER;
 
+  int deviceCount = 0;
   for (int i = 0; i < MAX_MASS_DEVICES; i++) {
     mountpoint[4] = i + '0';
     // Wait for IOP to initialize device driver
-    for (int i = 0; i < 2; i++) {
+    for (int wait = 0; wait < 2; wait++) {
       delay(2);
       directory = opendir(mountpoint);
       if (directory != NULL) {
@@ -92,6 +93,7 @@ int initDeviceMap() {
       printf("ERROR: failed to get driver for device %s\n", mountpoint);
       return -EIO;
     }
+    deviceCount++;
   }
-  return 0;
+  return deviceCount;
 }

--- a/src/iso_cache.c
+++ b/src/iso_cache.c
@@ -13,7 +13,7 @@
 #define CACHE_VERSION 2
 
 const char titleIDCacheFile[] = "/cache.bin";
-#define MAX_CACHE_PATH_LEN MAX_STORAGE_BASE_PATH_LEN + BASE_CONFIG_PATH_LEN + (sizeof(titleIDCacheFile) / sizeof(char))
+#define MAX_CACHE_PATH_LEN MASS_PLACEHOLDER_LEN + BASE_CONFIG_PATH_LEN + (sizeof(titleIDCacheFile) / sizeof(char))
 
 // Structs used to read and write cache file contents
 typedef struct {

--- a/src/iso_cache.c
+++ b/src/iso_cache.c
@@ -2,6 +2,7 @@
 #include "iso_cache.h"
 #include "common.h"
 #include "iso.h"
+#include "devices.h"
 #include "options.h"
 #include <malloc.h>
 #include <ps2sdkapi.h>
@@ -9,10 +10,10 @@
 #include <string.h>
 
 #define CACHE_MAGIC "NIDC"
-#define CACHE_VERSION 1
+#define CACHE_VERSION 2
 
 const char titleIDCacheFile[] = "/cache.bin";
-#define MAX_CACHE_PATH_LEN STORAGE_BASE_PATH_LEN + BASE_CONFIG_PATH_LEN + (sizeof(titleIDCacheFile) / sizeof(char))
+#define MAX_CACHE_PATH_LEN MAX_STORAGE_BASE_PATH_LEN + BASE_CONFIG_PATH_LEN + (sizeof(titleIDCacheFile) / sizeof(char))
 
 // Structs used to read and write cache file contents
 typedef struct {
@@ -26,20 +27,10 @@ typedef struct {
   int total;       // Total number of elements in cache file
 } CacheMetadata;
 
-// Saves TargetList into title ID cache
+// Saves TargetList into title ID cache on every storage device
 int storeTitleIDCache(TargetList *list) {
   if (list->total == 0) {
     return 0;
-  }
-
-  char cachePath[MAX_CACHE_PATH_LEN];
-
-  // Get path to config directory and make sure it exists
-  buildConfigFilePath(cachePath, NULL);
-  struct stat st;
-  if (stat(cachePath, &st) == -1) {
-    printf("Creating config directory: %s\n", cachePath);
-    mkdir(cachePath, 0777);
   }
 
   // Get total number of valid cache entries
@@ -56,57 +47,85 @@ int storeTitleIDCache(TargetList *list) {
     return 0;
   }
 
-  // Open cache file for writing
-  buildConfigFilePath(cachePath, titleIDCacheFile);
-  FILE *file = fopen(cachePath, "wb");
-  if (file == NULL) {
-    printf("ERROR: failed to open cache file for writing\n");
-    return -EIO;
-  }
+  // Prepare paths and header
+  char cachePath[MAX_CACHE_PATH_LEN];
+  char dirPath[MAX_CACHE_PATH_LEN];
+  buildConfigFilePath(dirPath, MASS_PLACEHOLDER, NULL);
+  buildConfigFilePath(cachePath, MASS_PLACEHOLDER, titleIDCacheFile);
 
-  int result;
-  // Write cache file header
-  CacheMetadata meta = {.magic = CACHE_MAGIC, .version = CACHE_VERSION, .total = total};
-  result = fwrite(&meta, sizeof(CacheMetadata), 1, file);
-  if (!result) {
-    printf("failed to write metadata: %d\n", errno);
-    fclose(file);
-    remove(cachePath);
-    return result;
-  }
-
-  // Write each entry
   CacheEntryHeader header;
-  curTitle = list->first;
-  while (curTitle != NULL) {
-    if (strlen(curTitle->id) < 11) {
-      // Ignore empty entries
-      curTitle = curTitle->next;
+  CacheMetadata meta = {.magic = CACHE_MAGIC, .version = CACHE_VERSION, .total = total};
+  for (int i = 0; i < MAX_MASS_DEVICES; i++) {
+    if (deviceModeMap[i].mode  == MODE_ALL) {
+      break;
+    }
+    cachePath[4] = i + '0';
+    dirPath[4] = i + '0';
+
+    // Get path to config directory and make sure it exists
+    struct stat st;
+    if (stat(dirPath, &st) == -1) {
+      printf("Creating config directory: %s\n", dirPath);
+      if (mkdir(dirPath, 0777)) {
+        printf("ERROR: Failed to create directory\n");
+        continue;
+      }
+    }
+
+    // Open cache file for writing
+    FILE *file = fopen(cachePath, "wb");
+    if (file == NULL) {
+      printf("ERROR: Failed to open cache file for writing\n");
       continue;
     }
 
-    // Write entry header
-    memcpy(header.titleID, curTitle->id, sizeof(header.titleID));
-    header.titleID[11] = '\0';
-    header.pathLength = strlen(curTitle->fullPath) + 1;
-    result = fwrite(&header, sizeof(CacheEntryHeader), 1, file);
+    int result;
+    // Write cache file header
+    result = fwrite(&meta, sizeof(CacheMetadata), 1, file);
     if (!result) {
-      printf("%s: failed to write header: %d\n", curTitle->name, errno);
+      printf("ERROR: Failed to write metadata: %d\n", errno);
       fclose(file);
       remove(cachePath);
       return result;
     }
-    // Write full ISO path
-    result = fwrite(curTitle->fullPath, header.pathLength, 1, file);
-    if (!result) {
-      printf("%s: failed to write full path: %d\n", curTitle->name, errno);
-      fclose(file);
-      remove(cachePath);
-      return result;
+
+    // Write each entry
+    curTitle = list->first;
+    while (curTitle != NULL) {
+      if (strlen(curTitle->id) < 11) {
+        // Ignore empty entries
+        curTitle = curTitle->next;
+        continue;
+      }
+
+      int mountpointLen = 5;
+      if (curTitle->fullPath[5] == ':') {
+        mountpointLen = 6;
+      }
+
+      // Write entry header
+      memcpy(header.titleID, curTitle->id, sizeof(header.titleID));
+      header.titleID[11] = '\0';
+      header.pathLength = strlen(curTitle->fullPath) - mountpointLen + 1;
+      result = fwrite(&header, sizeof(CacheEntryHeader), 1, file);
+      if (!result) {
+        printf("ERROR: %s: Failed to write header: %d\n", curTitle->name, errno);
+        fclose(file);
+        remove(cachePath);
+        return result;
+      }
+      // Write full ISO path without the mountpoint
+      result = fwrite(curTitle->fullPath + mountpointLen, header.pathLength, 1, file);
+      if (!result) {
+        printf("ERROR: %s: Failed to write full path: %d\n", curTitle->name, errno);
+        fclose(file);
+        remove(cachePath);
+        return result;
+      }
+      curTitle = curTitle->next;
     }
-    curTitle = curTitle->next;
+    fclose(file);
   }
-  fclose(file);
   return 0;
 }
 
@@ -117,13 +136,22 @@ int loadTitleIDCache(TitleIDCache *cache) {
 
   // Open cache file for reading
   char cachePath[MAX_CACHE_PATH_LEN];
-  buildConfigFilePath(cachePath, titleIDCacheFile);
+  buildConfigFilePath(cachePath, MASS_PLACEHOLDER, titleIDCacheFile);
 
-  FILE *file = fopen(cachePath, "rb");
-  if (file == NULL) {
-    printf("ERROR: failed to open cache file\n");
-    return -ENOENT;
+  FILE *file;
+  // Load the first found cache file
+  for (int i = 0; i < MAX_MASS_DEVICES; i++) {
+    if (deviceModeMap[i].mode  == MODE_ALL) {
+      printf("ERROR: failed to open cache file\n");
+      return -ENOENT;
+    }
+    cachePath[4] = i + '0';
+
+    file = fopen(cachePath, "rb");
+    if (file != NULL)
+      break;
   }
+
   int result;
 
   // Read cache file header
@@ -199,8 +227,14 @@ char *getCachedTitleID(char *fullPath, TitleIDCache *cache) {
   // This code takes advantage of all entries in the title list being sorted alphabetically.
   // By starting from the index of the last matched entry, we can skip comparing fullPath with entries
   // that have already been matched to a title ID, improving lookup speeds for very large lists.
+
+  int mountpointLen = 5;
+  if (fullPath[5] == ':') {
+    mountpointLen = 6;
+  }
+
   for (int i = cache->lastMatchedIdx; i < cache->total; i++) {
-    if (!strcmp(cache->entries[i].fullPath, fullPath)) {
+    if (!strcmp(cache->entries[i].fullPath, fullPath + mountpointLen)) {
       cache->lastMatchedIdx = i;
       return cache->entries[i].titleID;
     }

--- a/src/main.c
+++ b/src/main.c
@@ -75,17 +75,12 @@ int main(int argc, char *argv[]) {
   }
 
   logString("Initializing BDM devices...\n");
-  if (initDeviceMap() < 0) {
+  res = initDeviceMap();
+  if ((res < 0)) {
     logString("ERROR: failed to initialize device\n");
     goto fail;
   }
-  // Count number of initialized devices (reusing res as a counter)
-  for (res = 0; res < MAX_MASS_DEVICES; res++) {
-    if (deviceModeMap[res].mode == MODE_ALL) {
-      break;
-    }
-  }
-  if (res == 0) {
+  if (!res) {
     logString("ERROR: No BDM devices found\n");
     goto fail;
   }

--- a/src/module_init.c
+++ b/src/module_init.c
@@ -107,13 +107,13 @@ int init_modules(char *basePath) {
   SifInitRpc(0);
 
   int ret, iopret = 0;
-  // // Apply patches required to load modules from EE RAM
+  // Apply patches required to load modules from EE RAM
   if ((ret = sbv_patch_enable_lmb()))
     return ret;
   if ((ret = sbv_patch_disable_prefix_check()))
     return ret;
 
-  // Load modules
+  // Load embedded modules
   IRX_LOAD(iomanX);
   IRX_LOAD(fileXio);
   IRX_LOAD(sio2man);
@@ -202,7 +202,6 @@ ExternalModule *buildExternalModuleList(char *basePath) {
     unsigned char *irxBuf = calloc(sizeof(char), fsize);
     if (irxBuf == NULL) {
       logString("\t%s: Failed to allocate memory\n", external_modules[i].name);
-      free(irxBuf);
       close(fd);
       goto fail;
     }

--- a/src/options.c
+++ b/src/options.c
@@ -1,17 +1,20 @@
 #include "options.h"
 #include "common.h"
+#include "devices.h"
 #include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <libcdvd.h>
 #include <ps2sdkapi.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-int parseOptionsFile(ArgumentList *result, FILE *file);
+int parseOptionsFile(ArgumentList *result, FILE *file, char deviceNumber);
 int loadArgumentList(ArgumentList *options, char *filePath);
 void appendArgument(ArgumentList *target, Argument *arg);
 Argument *newArgument(char *argName, char *value);
+uint32_t getTimestamp();
 
 // Defines all known compatibility modes
 const CompatiblityModeMap COMPAT_MODE_MAP[CM_NUM_MODES] = {
@@ -26,16 +29,22 @@ const char BASE_CONFIG_PATH[] = "/nhddl";
 const size_t BASE_CONFIG_PATH_LEN = sizeof(BASE_CONFIG_PATH) / sizeof(char);
 
 const char globalOptionsPath[] = "/global.yaml";
-#define MAX_GLOBAL_OPTS_LEN (STORAGE_BASE_PATH_LEN + BASE_CONFIG_PATH_LEN + (sizeof(globalOptionsPath) / sizeof(char)))
+#define MAX_GLOBAL_OPTS_LEN (MAX_STORAGE_BASE_PATH_LEN + BASE_CONFIG_PATH_LEN + (sizeof(globalOptionsPath) / sizeof(char)))
 
-const char lastTitlePath[] = "/lastTitle.txt";
-#define MAX_LAST_TITLE_LEN (STORAGE_BASE_PATH_LEN + BASE_CONFIG_PATH_LEN + (sizeof(lastTitlePath) / sizeof(char)))
+const char lastTitlePath[] = "/lastTitle.bin";
+#define MAX_LAST_TITLE_LEN (MAX_STORAGE_BASE_PATH_LEN + BASE_CONFIG_PATH_LEN + (sizeof(lastTitlePath) / sizeof(char)))
 
 // Writes full path to targetFileName into targetPath.
 // If targetFileName is NULL, will return path to config directory
-void buildConfigFilePath(char *targetPath, const char *targetFileName) {
-  targetPath[0] = '\0';
-  strcat(targetPath, STORAGE_BASE_PATH);
+void buildConfigFilePath(char *targetPath, const char *targetMountpoint, const char *targetFileName) {
+  if (targetMountpoint[4] == ':') {
+    strncpy(targetPath, targetMountpoint, 5);
+    targetPath[5] = '\0';
+  } else { // Handle numbered devices
+    strncpy(targetPath, targetMountpoint, 6);
+    targetPath[6] = '\0';
+  }
+
   strcat(targetPath, BASE_CONFIG_PATH); // Append base config path
   if (targetFileName != NULL) {
     // Append / to path if targetFileName doesn't have it already
@@ -47,40 +56,62 @@ void buildConfigFilePath(char *targetPath, const char *targetFileName) {
 }
 
 // Gets last launched title path into titlePath
+// Searches for the latest file across all mounted BDM devices
 int getLastLaunchedTitle(char *titlePath) {
   printf("Reading last launched title\n");
   char targetPath[MAX_LAST_TITLE_LEN];
   targetPath[0] = '\0';
-  buildConfigFilePath(targetPath, lastTitlePath);
+  buildConfigFilePath(targetPath, MASS_PLACEHOLDER, lastTitlePath);
 
-  // Open last launched title file and read it
-  int fd = open(targetPath, O_RDONLY);
-  if (fd < 0) {
-    printf("WARN: Failed to open last launched title file: %d\n", fd);
-    return -ENOENT;
-  }
+  uint32_t max_timestamp = 0;
+  uint32_t timestamp = 0;
+  size_t fsize = 0;
+  for (int i = 0; i < MAX_MASS_DEVICES; i++) {
+    if (deviceModeMap[i].mode == MODE_ALL) {
+      break;
+    }
+    targetPath[4] = i + '0';
 
-  // Determine file size
-  struct stat st;
-  if (fstat(fd, &st)) {
+    // Open last launched title file and read it
+    int fd = open(targetPath, O_RDONLY);
+    if (fd < 0) {
+      printf("WARN: Failed to open last launched title file on device %d: %d\n", i, fd);
+      continue;
+    }
+
+    // Read file timestamp (first 4 bytes)
+    if (read(fd, &timestamp, sizeof(timestamp)) != sizeof(timestamp)) {
+      printf("WARN: Failed to read last launched title file on device %d\n", i);
+      close(fd);
+      continue;
+    }
+    // Read the rest of the file only if it's newer
+    if (timestamp < max_timestamp) {
+      close(fd);
+      continue;
+    }
+    max_timestamp = timestamp;
+
+    // Get title path size
+    fsize = lseek(fd, 0, SEEK_END) - sizeof(timestamp);
+    lseek(fd, sizeof(timestamp), SEEK_SET);
+    // Read file contents into titlePath
+    if (read(fd, titlePath, fsize) <= 0) {
+      close(fd);
+      printf("WARN: Failed to read last launched title\n");
+      continue;
+    }
     close(fd);
-    return -EIO;
+    return 0;
   }
-  // Read file contents into titlePath
-  if (read(fd, titlePath, st.st_size) < 0) {
-    close(fd);
-    printf("WARN: Failed to read last launched title\n");
-    return -EIO;
-  }
-  close(fd);
   return 0;
 }
 
-// Writes last launched title path into lastTitle file
+// Writes last launched title path into lastTitle file on title mountpoint
 int updateLastLaunchedTitle(char *titlePath) {
   printf("Writing last launched title as %s\n", titlePath);
   char targetPath[MAX_LAST_TITLE_LEN];
-  buildConfigFilePath(targetPath, NULL);
+  buildConfigFilePath(targetPath, titlePath, NULL);
 
   // Make sure config directory exists
   struct stat st;
@@ -98,8 +129,23 @@ int updateLastLaunchedTitle(char *titlePath) {
     printf("ERROR: Failed to open last launched title file: %d\n", fd);
     return -ENOENT;
   }
-  size_t writeLen = strlen(titlePath) + 1;
-  if (write(fd, titlePath, writeLen) != writeLen) {
+
+  // Write timestamp
+  uint32_t timestamp = getTimestamp();
+  if (write(fd, &timestamp, sizeof(timestamp)) != sizeof(timestamp)) {
+    printf("ERROR: Failed to write last launched title timestamp\n");
+    close(fd);
+    return -EIO;
+  }
+
+  // Write path without the mountpoint
+  int mountpointLen = 5;
+  if (titlePath[5] == ':') {
+    mountpointLen = 6;
+  }
+
+  size_t writeLen = strlen(titlePath) + 1 - mountpointLen;
+  if (write(fd, titlePath + mountpointLen, writeLen) != writeLen) {
     printf("ERROR: Failed to write last launched title\n");
     close(fd);
     return -EIO;
@@ -108,10 +154,10 @@ int updateLastLaunchedTitle(char *titlePath) {
   return 0;
 }
 
-// Generates ArgumentList from global config file
-int getGlobalLaunchArguments(ArgumentList *result) {
+// Generates ArgumentList from global config file located at targetMounpoint (usually ISO full path)
+int getGlobalLaunchArguments(ArgumentList *result, const char *targetMountpoint) {
   char targetPath[MAX_GLOBAL_OPTS_LEN];
-  buildConfigFilePath(targetPath, globalOptionsPath);
+  buildConfigFilePath(targetPath, targetMountpoint, globalOptionsPath);
   int ret = loadArgumentList(result, targetPath);
 
   Argument *curArg = result->first;
@@ -126,7 +172,7 @@ int getGlobalLaunchArguments(ArgumentList *result) {
 int getTitleLaunchArguments(ArgumentList *result, Target *target) {
   printf("Looking for title-specific config for %s (%s)\n", target->name, target->id);
   char targetPath[PATH_MAX + 1];
-  buildConfigFilePath(targetPath, NULL);
+  buildConfigFilePath(targetPath, target->fullPath, NULL);
   // Determine actual title options file from config directory contents
   DIR *directory = opendir(targetPath);
   if (directory == NULL) {
@@ -141,7 +187,7 @@ int getTitleLaunchArguments(ArgumentList *result, Target *target) {
     if (entry->d_type != DT_DIR) {
       // Find file that starts with ISO name (without the extension)
       if (!strncmp(entry->d_name, target->name, strlen(target->name))) {
-        buildConfigFilePath(targetPath, entry->d_name);
+        buildConfigFilePath(targetPath, target->fullPath, entry->d_name);
         break;
       }
     }
@@ -169,7 +215,7 @@ int getTitleLaunchArguments(ArgumentList *result, Target *target) {
 int updateTitleLaunchArguments(Target *target, ArgumentList *options) {
   // Build file path
   char lineBuffer[PATH_MAX + 1];
-  buildConfigFilePath(lineBuffer, target->name);
+  buildConfigFilePath(lineBuffer, target->fullPath, target->name);
   strcat(lineBuffer, ".yaml");
   printf("Saving title-specific config to %s\n", lineBuffer);
 
@@ -221,8 +267,11 @@ int loadArgumentList(ArgumentList *options, char *filePath) {
   options->first = NULL;
   options->last = NULL;
 
+  // Get driver device number (will be used by Neutrino)
+  char deviceNumber = deviceModeMap[filePath[4] - '0'].index + '0';
+
   // Parse options file
-  if (parseOptionsFile(options, file)) {
+  if (parseOptionsFile(options, file, deviceNumber)) {
     fclose(file);
     freeArgumentList(options);
     return -EIO;
@@ -233,7 +282,8 @@ int loadArgumentList(ArgumentList *options, char *filePath) {
 }
 
 // Parses file into ArgumentList. Result may contain parsed arguments even if an error is returned.
-int parseOptionsFile(ArgumentList *result, FILE *file) {
+// Replaces 'X' in argument values that start with MASS_PLACEHOLDER with the deviceNumber
+int parseOptionsFile(ArgumentList *result, FILE *file, char deviceNumber) {
   // Our lines will mostly consist of file paths, which aren't likely to exceed 300 characters due to 255 character limit in exFAT path component
   char lineBuffer[PATH_MAX + 1];
   lineBuffer[0] = '\0';
@@ -241,6 +291,7 @@ int parseOptionsFile(ArgumentList *result, FILE *file) {
   int substrIdx;
   int argEndIdx;
   int isDisabled = 0;
+
   while (fgets(lineBuffer, PATH_MAX, file)) { // fgets reutrns NULL if EOF or an error occurs
     startIdx = 0;
     isDisabled = 0;
@@ -326,6 +377,10 @@ int parseOptionsFile(ArgumentList *result, FILE *file) {
 
     // Copy the value and add argument to the list
     strncpy(arg->value, &lineBuffer[startIdx], valueLength);
+    // Replace X in path with the actual device number if argument starts with MASS_PLACEHOLDER
+    if (!strncmp(arg->value, MASS_PLACEHOLDER, MAX_STORAGE_BASE_PATH_LEN)) {
+      arg->value[4] = deviceNumber;
+    }
     appendArgument(result, arg);
 
   next:
@@ -518,7 +573,7 @@ ArgumentList *loadLaunchArgumentLists(Target *target) {
   int res = 0;
   // Initialize global argument list
   ArgumentList *globalArguments = calloc(sizeof(ArgumentList), 1);
-  if ((res = getGlobalLaunchArguments(globalArguments))) {
+  if ((res = getGlobalLaunchArguments(globalArguments, target->fullPath))) {
     printf("WARN: Failed to load global launch arguments: %d\n", res);
   }
   // Initialize title list and merge global into it
@@ -536,4 +591,28 @@ ArgumentList *loadLaunchArgumentLists(Target *target) {
   // If there are no title arguments, use global arguments directly
   free(titleArguments);
   return globalArguments;
+}
+
+// Generates 32-bit timestamp from RTC.
+// Will wrap around every 64th year
+uint32_t getTimestamp() {
+  // Initialize libcdvd to get timestamp
+  if (sceCdInit(SCECdINoD)) {
+    // Read clock
+    sceCdCLOCK time;
+    sceCdReadClock(&time);
+    sceCdInit(SCECdEXIT);
+
+    // Pack date into 32-bit timestamp
+    // Y   26 M 22 D  17 H  12 M    6 S    0
+    // 111111 1111 11111 11111 111111 111111
+    uint32_t sum = ((uint32_t)btoi(time.year)) << 26 |        // Year
+                   ((uint32_t)btoi(time.month) & 0xF) << 22 | // Month
+                   ((uint32_t)btoi(time.day)) << 17 |         // Day
+                   ((uint32_t)btoi(time.hour)) << 12 |        // Hour
+                   ((uint32_t)btoi(time.minute)) << 6 |       // Minute
+                   (btoi(time.second) & 0x3F);                // Second
+    return sum;
+  }
+  return 0;
 }

--- a/src/options.c
+++ b/src/options.c
@@ -29,10 +29,10 @@ const char BASE_CONFIG_PATH[] = "/nhddl";
 const size_t BASE_CONFIG_PATH_LEN = sizeof(BASE_CONFIG_PATH) / sizeof(char);
 
 const char globalOptionsPath[] = "/global.yaml";
-#define MAX_GLOBAL_OPTS_LEN (MAX_STORAGE_BASE_PATH_LEN + BASE_CONFIG_PATH_LEN + (sizeof(globalOptionsPath) / sizeof(char)))
+#define MAX_GLOBAL_OPTS_LEN (MASS_PLACEHOLDER_LEN + BASE_CONFIG_PATH_LEN + (sizeof(globalOptionsPath) / sizeof(char)))
 
 const char lastTitlePath[] = "/lastTitle.bin";
-#define MAX_LAST_TITLE_LEN (MAX_STORAGE_BASE_PATH_LEN + BASE_CONFIG_PATH_LEN + (sizeof(lastTitlePath) / sizeof(char)))
+#define MAX_LAST_TITLE_LEN (MASS_PLACEHOLDER_LEN + BASE_CONFIG_PATH_LEN + (sizeof(lastTitlePath) / sizeof(char)))
 
 // Writes full path to targetFileName into targetPath.
 // If targetFileName is NULL, will return path to config directory
@@ -378,7 +378,7 @@ int parseOptionsFile(ArgumentList *result, FILE *file, char deviceNumber) {
     // Copy the value and add argument to the list
     strncpy(arg->value, &lineBuffer[startIdx], valueLength);
     // Replace X in path with the actual device number if argument starts with MASS_PLACEHOLDER
-    if (!strncmp(arg->value, MASS_PLACEHOLDER, MAX_STORAGE_BASE_PATH_LEN)) {
+    if (!strncmp(arg->value, MASS_PLACEHOLDER, MASS_PLACEHOLDER_LEN)) {
       arg->value[4] = deviceNumber;
     }
     appendArgument(result, arg);


### PR DESCRIPTION
Inspired by @AKuHAK's fork and discussion in #10, this PR brings the following changes:
- Support for searching and launching ISOs from multiple BDM devices
- Title cache now contains relative paths
- Last title file now contains timestamp and is renamed to `lastTitle.bin`
- Neutrino arguments containing file paths must start with `massX:` instead of `mass:`
- Memory card-only restriction has been lifted: NHDDL can be loaded from any device as long as IOP modules are still loaded before NHDDL reboots the IOP.

Original single-mode behavior is preserved and can be enabled by setting `mode` option in `nhddl.yaml`