### PR TITLE
UI bugfixes, README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ NHDDL requires a full [Neutrino](https://github.com/rickgaiser/neutrino) install
 By default, NHDDL tries to initialize all supported devices. You can override this behavior and reduce initialization times by setting specific mode in launcher configuration file.  
 See [this](#launcher-configuration-file) section for details on `nhddl.yml`.
 
-**Do not plug in any USB mass storage devices while running NHDDL!**  
+**Do not plug in any BDM storage devices while running NHDDL!**  
 Doing so might crash NHDDL and/or possibly corrupt the files on your target device due to how BDM drivers work.
 
 NHDDL comes in two versions: _standalone_ and _non-standalone_.
@@ -33,16 +33,33 @@ NHDDL comes in two versions: _standalone_ and _non-standalone_.
 ### Standalone version
 
 The standalone version of NHDDL doesn't require any Neutrino modules and will boot from any device.  
-It makes the `nhddl.elf` larger, but allows NHDDL to support ELF loaders that unload everything before launchining NHDDL from USB.
+It makes the `nhddl.elf` larger, but allows NHDDL to support ELF loaders that unload everything before launchining NHDDL from BDM devices.
 
 Note that Neutrino is still required for NHDDL to launch your ISOs.
 
+#### Manual installation
+
+To use NHDDL:
 - Get the [latest `nhddl.elf`](https://github.com/pcm720/nhddl/releases)
 - Copy `nhddl.elf` to your memory card or storage device wherever you want.
 - _Additional step if you need only ATA, USB, MX4SIO, UDPBD or iLink_:  
   Modify `nhddl.yaml` [accordingly](#common-use-cases) and copy it next to `nhddl.elf`
-- Get the [latest Neutrino release](https://github.com/rickgaiser/neutrino/releases)
+- Get the [latest Neutrino release](https://github.com/rickgaiser/neutrino/releases/tag/latest)
 - Copy Neutrino folder to the root of your PS2 memory card or your storage device. 
+
+#### Save Application System PSU
+
+You can also get NHDDL as an easy-to-use PSU package [here](https://pcm720.github.io/nhddl-psu/).  
+To install it:
+- Copy generated `nhddl.psu` to your USB drive
+- Open wLaunchELF on your PS2
+- Choose your USB device and copy `nhddl.psu`
+- Go back and open your memory card (`mc0` or `mc1`)
+- Open file menu and select `psuPaste`
+- Get the [latest Neutrino release](https://github.com/rickgaiser/neutrino/releases/tag/latest)
+- Copy Neutrino folder to the root of your PS2 memory card or your storage device. 
+
+This will install NHDDL to your memory card along with the PS2 Browser icon.
  
 Updating `nhddl.elf` is as simple as replacing `nhddl.elf` with the latest version.
 
@@ -50,18 +67,19 @@ Updating `nhddl.elf` is as simple as replacing `nhddl.elf` with the latest versi
 
 Use this version to save space on your memory card.
 
-- Get the [latest Neutrino release](https://github.com/rickgaiser/neutrino/releases)
+- Get the [latest Neutrino release](https://github.com/rickgaiser/neutrino/releases/tag/latest)
 - Get the [latest `nhddl.elf`](https://github.com/pcm720/nhddl/releases)
 - Unpack Neutrino release
 - Copy `nhddl.elf` to Neutrino folder next to `neutrino.elf`
 - _Additional step if you need only ATA, USB, MX4SIO, UDPBD or iLink_:  
   Modify `nhddl.yaml` [accordingly](#common-use-cases) and copy it next to `nhddl.elf`
-- Copy Neutrino folder to your PS2 memory card or your USB device.
+- Copy Neutrino folder to your PS2 memory card or your storage device.
 
 Updating `nhddl.elf` is as simple as replacing `nhddl.elf` with the latest version.
 
-If you're getting `Failed to prepare external modules` error while trying to run NHDDL from the USB drive, MX4SIO, iLink or UDPBD, make sure your ELF launcher initializes
-USB modules and doesn't reset the IOP before loading NHDDL.  
+You can also install NHDDL from a PSU package (see [this section](#save-application-system-psu)), but you'll need to copy Neutrino installation manually using wLaunchELF or another PS2-based file manager.
+
+If you're getting `Failed to prepare external modules` error while trying to run NHDDL from the USB drive, MX4SIO, iLink or UDPBD, make sure your ELF launcher initializes BDM modules and doesn't reset the IOP before loading NHDDL.  
 If this is the case, you __must__ place Neutrino on the memory card or use standalone version instead.
 
 The non-standalone version of NHDDL reuses Neutrino modules for BDM support and requires them to be present in Neutrino `modules` directory, which makes `nhddl.elf` significantly smaller.  

--- a/src/gui.c
+++ b/src/gui.c
@@ -342,7 +342,7 @@ void drawTitleList(TargetList *titles, int selectedTitleIdx, int maxTitlesPerPag
     }
 
     // Draw title name
-    titleY = drawText(baseX, titleY, 0, coverArtX1, 0, ((selectedTitleIdx == curTitle->idx) ? ColorSelected : FontMainColor), curTitle->name);
+    titleY = drawText(baseX, titleY, 0, coverArtX1-5, 0, ((selectedTitleIdx == curTitle->idx) ? ColorSelected : FontMainColor), curTitle->name);
 
   next:
     curTitle = curTitle->next;

--- a/src/gui_graphics.c
+++ b/src/gui_graphics.c
@@ -154,7 +154,7 @@ uint8_t getFontLineHeight() { return font.lineHeight; }
 // Returns pointer to the glyph or NULL if the font doesn't have a glyph for this character
 const BMFontChar *getGlyph(uint32_t character) {
   for (int i = 0; i < font.bucketCount; i++) {
-    if ((font.buckets[i].startChar <= character) || (font.buckets[i].endChar >= character)) {
+    if ((font.buckets[i].startChar <= character) && (font.buckets[i].endChar >= character)) {
       return &font.buckets[i].chars[character - font.buckets[i].startChar];
     }
   }
@@ -199,7 +199,6 @@ int drawText(int x, int y, int z, int maxWidth, int maxHeight, uint64_t color, c
 
     glyph = getGlyph(text[i]);
     if (glyph == NULL) {
-      printf("WARN: Unknown character %d\n", text[i]);
       continue;
     }
 
@@ -317,7 +316,6 @@ int drawTextWindow(int x1, int y1, int x2, int y2, int z, uint64_t color, uint8_
 
     glyph = getGlyph(text[i]);
     if (glyph == NULL) {
-      printf("WARN: Unknown character %d\n", text[i]);
       continue;
     }
 


### PR DESCRIPTION
This PR fixes the following issues:
- Very long title names going over the covert art zone
- getGlyph returning invalid pointers if character is not present in the font pages, causing NHDDL to crash

This PR also adds links to PSU generator and extends usage instructions.